### PR TITLE
UX: apply shared interaction feedback to Calendar and Stats

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -2,10 +2,10 @@ import React, { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Box } from '@/components/ui/box'
 import { Text } from '@/components/ui/text'
-import { Pressable } from '@/components/ui/pressable'
 import { HStack } from '@/components/ui/hstack'
 import { VStack } from '@/components/ui/vstack'
 import { IconSymbol } from '@/components/ui/icon-symbol'
+import { AppPressable } from '@/src/components/AppPressable'
 import { formatDate } from '@/src/utils/dateUtils'
 
 interface CalendarProps {
@@ -190,15 +190,17 @@ export const Calendar: React.FC<CalendarProps> = ({
     <Box className="flex-1 bg-white" testID="calendar-component">
       {/* Header with month navigation - matching Figma design */}
       <HStack className="items-center justify-between px-6 py-4 mb-4">
-        <Pressable
+        <AppPressable
+          feedback="select"
           onPress={() => navigateMonth('prev')}
           testID="calendar-prev-month"
           className="p-2 min-w-[44px] min-h-[44px] items-center justify-center"
+          pressedClassName="bg-gray-100 rounded-full"
           accessibilityLabel={t('calendar.prevMonth')}
           accessibilityRole="button"
         >
           <IconSymbol name="chevron.left" size={20} color="#666" />
-        </Pressable>
+        </AppPressable>
 
         <Text
           className="text-lg font-semibold text-gray-800"
@@ -207,15 +209,17 @@ export const Calendar: React.FC<CalendarProps> = ({
           {monthTitle}
         </Text>
 
-        <Pressable
+        <AppPressable
+          feedback="select"
           onPress={() => navigateMonth('next')}
           testID="calendar-next-month"
           className="p-2 min-w-[44px] min-h-[44px] items-center justify-center"
+          pressedClassName="bg-gray-100 rounded-full"
           accessibilityLabel={t('calendar.nextMonth')}
           accessibilityRole="button"
         >
           <IconSymbol name="chevron.right" size={20} color="#666" />
-        </Pressable>
+        </AppPressable>
       </HStack>
 
       {/* Days of week header - matching Figma spacing */}
@@ -244,13 +248,17 @@ export const Calendar: React.FC<CalendarProps> = ({
             {week.map((dayData, dayIndex) => {
               const completionCount = achievementData[dayData.dateString] || 0
               const heatmapColor = getHeatmapColor(completionCount)
+              const isSelectedDate = isSelected(dayData.dateString)
 
               return (
-                <Pressable
+                <AppPressable
                   key={`${weekIndex}-${dayIndex}`}
+                  feedback="select"
                   onPress={() => onDateSelect(dayData.dateString)}
                   testID={`calendar-date-${dayData.dateString}`}
                   className="flex-1 min-w-[44px] min-h-[48px]"
+                  pressedClassName="opacity-80"
+                  selected={isSelectedDate}
                   accessibilityLabel={getDateA11yLabel(dayData.date, dayData.dateString, completionCount)}
                   accessibilityRole="button"
                 >
@@ -264,7 +272,7 @@ export const Calendar: React.FC<CalendarProps> = ({
                       h-12 items-center justify-center rounded-xl
                       ${dayData.isCurrentMonth ? heatmapColor : 'bg-gray-50'}
                       ${
-                        isSelected(dayData.dateString)
+                        isSelectedDate
                           ? 'border-2 border-blue-500'
                           : ''
                       }
@@ -283,14 +291,14 @@ export const Calendar: React.FC<CalendarProps> = ({
                             ? 'text-gray-800'
                             : 'text-gray-300'
                         }
-                        ${isSelected(dayData.dateString) ? 'text-blue-600' : ''}
+                        ${isSelectedDate ? 'text-blue-600' : ''}
                         ${isToday(dayData.dateString) ? 'text-orange-600' : ''}
                       `}
                     >
                       {dayData.date}
                     </Text>
                   </Box>
-                </Pressable>
+                </AppPressable>
               )
             })}
           </HStack>

--- a/src/components/Statistics.tsx
+++ b/src/components/Statistics.tsx
@@ -3,10 +3,10 @@ import { ScrollView } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { Box } from '@/components/ui/box'
 import { Text } from '@/components/ui/text'
-import { Pressable } from '@/components/ui/pressable'
 import { HStack } from '@/components/ui/hstack'
 import { VStack } from '@/components/ui/vstack'
 import { IconSymbol } from '@/components/ui/icon-symbol'
+import { AppPressable } from '@/src/components/AppPressable'
 import { StatsData, Category } from '@/src/types'
 import { getCategoryDisplayName } from '@/src/i18n/config'
 
@@ -98,10 +98,13 @@ export const Statistics: React.FC<StatisticsProps> = ({
           <VStack space="md">
             {/* Period Toggle */}
             <HStack className="bg-gray-200 rounded-lg p-1">
-              <Pressable
+              <AppPressable
+                feedback="select"
                 onPress={() => setSelectedPeriod('week')}
                 testID="stats-week-toggle"
                 className="flex-1"
+                pressedClassName="opacity-80"
+                selected={selectedPeriod === 'week'}
                 accessibilityLabel={t('stats.showWeekStats')}
                 accessibilityRole="button"
               >
@@ -124,12 +127,15 @@ export const Statistics: React.FC<StatisticsProps> = ({
                     {t('stats.thisWeek')}
                   </Text>
                 </Box>
-              </Pressable>
+              </AppPressable>
 
-              <Pressable
+              <AppPressable
+                feedback="select"
                 onPress={() => setSelectedPeriod('month')}
                 testID="stats-month-toggle"
                 className="flex-1"
+                pressedClassName="opacity-80"
+                selected={selectedPeriod === 'month'}
                 accessibilityLabel={t('stats.showMonthStats')}
                 accessibilityRole="button"
               >
@@ -154,7 +160,7 @@ export const Statistics: React.FC<StatisticsProps> = ({
                     {t('stats.thisMonth')}
                   </Text>
                 </Box>
-              </Pressable>
+              </AppPressable>
             </HStack>
           </VStack>
 

--- a/src/components/__tests__/Calendar.test.tsx
+++ b/src/components/__tests__/Calendar.test.tsx
@@ -60,6 +60,23 @@ describe('Calendar', () => {
     )
   })
 
+  it('marks the selected date cell for assistive technologies', () => {
+    // Arrange
+    const { getByTestId } = render(<Calendar {...defaultProps} />)
+
+    // Act
+    const selectedDate = getByTestId('calendar-date-2024-01-15')
+    const unselectedDate = getByTestId('calendar-date-2024-01-10')
+
+    // Assert
+    expect(selectedDate.props.accessibilityState).toMatchObject({
+      selected: true,
+    })
+    expect(unselectedDate.props.accessibilityState).toMatchObject({
+      selected: false,
+    })
+  })
+
   it('navigates to previous month', () => {
     const { getByTestId, getByText } = render(<Calendar {...defaultProps} />)
 

--- a/src/components/__tests__/Statistics.test.tsx
+++ b/src/components/__tests__/Statistics.test.tsx
@@ -87,6 +87,39 @@ describe('Statistics', () => {
     expect(getByText('25日')).toBeTruthy()
   })
 
+  it('marks the active stats period for assistive technologies', () => {
+    // Arrange
+    const { getByTestId } = render(<Statistics {...defaultProps} />)
+
+    // Act
+    const weeklyToggle = getByTestId('stats-week-toggle')
+    const monthlyToggle = getByTestId('stats-month-toggle')
+
+    // Assert
+    expect(weeklyToggle.props.accessibilityState).toMatchObject({
+      selected: true,
+    })
+    expect(monthlyToggle.props.accessibilityState).toMatchObject({
+      selected: false,
+    })
+  })
+
+  it('moves the selected accessibility state when the monthly stats period is opened', () => {
+    // Arrange
+    const { getByTestId } = render(<Statistics {...defaultProps} />)
+
+    // Act
+    fireEvent.press(getByTestId('stats-month-toggle'))
+
+    // Assert
+    expect(getByTestId('stats-week-toggle').props.accessibilityState).toMatchObject({
+      selected: false,
+    })
+    expect(getByTestId('stats-month-toggle').props.accessibilityState).toMatchObject({
+      selected: true,
+    })
+  })
+
   it('switches back to weekly stats when weekly toggle is pressed', () => {
     const { getByTestId, getByText } = render(<Statistics {...defaultProps} />)
 


### PR DESCRIPTION
## Summary
- Replace raw Calendar month/date press targets with AppPressable feedback and selected accessibility state.
- Replace Statistics period toggles with AppPressable feedback and selected accessibility state.
- Add focused component coverage for the selected accessibility state contract.

## Validation
- pnpm typecheck
- pnpm lint
- pnpm exec jest --runInBand
- pnpm exec jest --runInBand --runTestsByPath src/components/__tests__/Calendar.test.tsx --testPathIgnorePatterns='^$' -t 'marks the selected date cell'
- pnpm exec jest --runInBand --runTestsByPath src/components/__tests__/Statistics.test.tsx --testPathIgnorePatterns='^$' -t 'assistive technologies|selected accessibility state'
- pnpm build:e2e
- pnpm test:e2e:production:single maestro/ios/06-calendar-browsing.yaml
- pnpm test:e2e:production:single maestro/ios/02-tab-navigation.yaml
- pnpm test:e2e:production:single maestro/ios/08-statistics.yaml
- pnpm test:e2e:production:single maestro/ios/04-task-completion.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Calendar date selection and month navigation now provide enhanced visual feedback when interacting with date cells and navigation buttons.
  * Period toggle controls for switching between week and month views include improved visual selection indicators.

* **Tests**
  * Added test coverage for calendar date accessibility metadata.
  * Added test coverage for period toggle accessibility state verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/Engage/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->