### PR TITLE
UX: add inline operation feedback

### DIFF
--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -19,6 +19,10 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'arrow.clockwise': 'refresh',
+  'checkmark.circle.fill': 'check-circle',
+  'exclamationmark.triangle.fill': 'warning',
+  'info.circle.fill': 'info',
 } as IconMapping;
 
 /**

--- a/maestro/ios/11-backup-create.yaml
+++ b/maestro/ios/11-backup-create.yaml
@@ -37,15 +37,14 @@ tags:
       text: "Data Backup"
     timeout: 5000
 
-# Create a local backup and assert the success alert appears.
-- tapOn: "Create Backup"
+# Create a local backup and assert inline feedback appears.
+- tapOn:
+    id: "backup-create-button"
 
 - extendedWaitUntil:
     visible:
-      text: "Backup Created"
+      id: "backup-operation-feedback"
     timeout: 10000
 
 - assertNotVisible:
     text: "Backup Failed"
-
-- tapOn: "OK"

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -49,6 +49,8 @@ jest.mock('react-native', () => {
   return {
     View: createNativeComponent('View'),
     Text: createNativeComponent('Text'),
+    TextInput: createNativeComponent('TextInput'),
+    SafeAreaView: createNativeComponent('SafeAreaView'),
     ScrollView: createNativeComponent('ScrollView'),
     Pressable,
     Modal,

--- a/src/components/BackupManager.tsx
+++ b/src/components/BackupManager.tsx
@@ -2,6 +2,11 @@ import React, { useState, useEffect, useCallback } from 'react'
 import { View, Text, ScrollView, Alert } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
+import {
+  OperationFeedback,
+  OperationFeedbackKind,
+} from '@/src/components/OperationFeedback'
+import { useInteractionFeedback } from '@/src/hooks/useInteractionFeedback'
 import { useAppStore } from '../stores/app-store'
 import i18n from '@/src/i18n/config'
 
@@ -21,14 +26,24 @@ interface BackupStats {
   validBackups: number
 }
 
+interface BackupFeedback {
+  kind: OperationFeedbackKind
+  message: string
+  actionLabel?: string
+  onAction?: () => void
+}
+
 /**
  * Component for managing data backups and exports
  */
 export const BackupManager: React.FC = () => {
   const { t } = useTranslation()
+  const triggerFeedback = useInteractionFeedback()
   const [backups, setBackups] = useState<BackupInfo[]>([])
   const [stats, setStats] = useState<BackupStats | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const [operationFeedback, setOperationFeedback] =
+    useState<BackupFeedback | null>(null)
 
   const {
     createBackup,
@@ -65,23 +80,45 @@ export const BackupManager: React.FC = () => {
     try {
       setIsLoading(true)
       clearError()
+      setOperationFeedback({
+        kind: 'saving',
+        message: t('backup.creating'),
+      })
 
       const result = await createBackup()
 
       if (result.success) {
-        Alert.alert(
-          t('backup.createSuccessTitle'),
-          t('backup.createSuccessMessage', { fileName: result.fileName, size: formatFileSize(result.size || 0) }),
-          [{ text: t('common.ok') }]
-        )
+        triggerFeedback('complete')
+        setOperationFeedback({
+          kind: 'success',
+          message: t('backup.createSuccessMessageInline', {
+            fileName: result.fileName,
+            size: formatFileSize(result.size || 0),
+          }),
+        })
         await loadBackupData()
       } else {
-        Alert.alert(t('backup.createFailTitle'), result.errors.join('\n'), [
-          { text: t('common.ok') },
-        ])
+        triggerFeedback('error')
+        setOperationFeedback({
+          kind: 'error',
+          message: result.errors.join('\n') || t('backup.createFailTitle'),
+          actionLabel: t('common.retry'),
+          onAction: () => {
+            void handleCreateBackup()
+          },
+        })
       }
     } catch (error) {
       console.error('Failed to create backup:', error)
+      triggerFeedback('error')
+      setOperationFeedback({
+        kind: 'error',
+        message: t('backup.createFailTitle'),
+        actionLabel: t('common.retry'),
+        onAction: () => {
+          void handleCreateBackup()
+        },
+      })
     } finally {
       setIsLoading(false)
     }
@@ -91,22 +128,93 @@ export const BackupManager: React.FC = () => {
     try {
       setIsLoading(true)
       clearError()
+      setOperationFeedback({
+        kind: 'saving',
+        message: t('backup.exporting'),
+      })
 
       const result = await exportData()
 
       if (result.success) {
-        Alert.alert(
-          t('backup.exportSuccessTitle'),
-          t('backup.exportSuccessMessage'),
-          [{ text: t('common.ok') }]
-        )
+        triggerFeedback('complete')
+        setOperationFeedback({
+          kind: 'success',
+          message: t('backup.exportSuccessMessage'),
+        })
       } else {
-        Alert.alert(t('backup.exportFailTitle'), result.errors.join('\n'), [
-          { text: t('common.ok') },
-        ])
+        triggerFeedback('error')
+        setOperationFeedback({
+          kind: 'error',
+          message: result.errors.join('\n') || t('backup.exportFailTitle'),
+          actionLabel: t('common.retry'),
+          onAction: () => {
+            void handleExportData()
+          },
+        })
       }
     } catch (error) {
       console.error('Failed to export data:', error)
+      triggerFeedback('error')
+      setOperationFeedback({
+        kind: 'error',
+        message: t('backup.exportFailTitle'),
+        actionLabel: t('common.retry'),
+        onAction: () => {
+          void handleExportData()
+        },
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const performImportBackup = async () => {
+    try {
+      setIsLoading(true)
+      clearError()
+      setOperationFeedback({
+        kind: 'saving',
+        message: t('backup.importing'),
+      })
+
+      const result = await importBackup()
+
+      if (result.success) {
+        triggerFeedback('complete')
+        setOperationFeedback({
+          kind: 'success',
+          message: t('backup.importSuccessMessageInline', {
+            categories: result.recordsImported.categories,
+            tasks: result.recordsImported.tasks,
+            entries: result.recordsImported.entries,
+            completions: result.recordsImported.completions,
+            settings: result.recordsImported.settings,
+          }),
+        })
+        await loadBackupData()
+        return
+      }
+
+      triggerFeedback('error')
+      setOperationFeedback({
+        kind: 'error',
+        message: result.errors.join('\n') || t('backup.importFailTitle'),
+        actionLabel: t('common.retry'),
+        onAction: () => {
+          void handleImportBackup()
+        },
+      })
+    } catch (error) {
+      console.error('Failed to import backup:', error)
+      triggerFeedback('error')
+      setOperationFeedback({
+        kind: 'error',
+        message: t('backup.importFailTitle'),
+        actionLabel: t('common.retry'),
+        onAction: () => {
+          void handleImportBackup()
+        },
+      })
     } finally {
       setIsLoading(false)
     }
@@ -121,40 +229,55 @@ export const BackupManager: React.FC = () => {
         {
           text: t('common.continue'),
           style: 'destructive',
-          onPress: async () => {
-            try {
-              setIsLoading(true)
-              clearError()
-
-              const result = await importBackup()
-
-              if (result.success) {
-                Alert.alert(
-                  t('backup.importSuccessTitle'),
-                  t('backup.importSuccessMessage', {
-                    categories: result.recordsImported.categories,
-                    tasks: result.recordsImported.tasks,
-                    entries: result.recordsImported.entries,
-                    completions: result.recordsImported.completions,
-                    settings: result.recordsImported.settings,
-                  }),
-                  [{ text: t('common.ok') }]
-                )
-                await loadBackupData()
-              } else {
-                Alert.alert(t('backup.importFailTitle'), result.errors.join('\n'), [
-                  { text: t('common.ok') },
-                ])
-              }
-            } catch (error) {
-              console.error('Failed to import backup:', error)
-            } finally {
-              setIsLoading(false)
-            }
+          onPress: () => {
+            void performImportBackup()
           },
         },
       ]
     )
+  }
+
+  const performDeleteBackup = async (fileName: string) => {
+    try {
+      setIsLoading(true)
+      setOperationFeedback({
+        kind: 'saving',
+        message: t('backup.deleting'),
+      })
+      const success = await deleteBackup(fileName)
+
+      if (success) {
+        triggerFeedback('complete')
+        setOperationFeedback({
+          kind: 'success',
+          message: t('backup.deleteSuccessMessage'),
+        })
+        await loadBackupData()
+      } else {
+        triggerFeedback('error')
+        setOperationFeedback({
+          kind: 'error',
+          message: t('backup.deleteFailMessage'),
+          actionLabel: t('common.retry'),
+          onAction: () => {
+            void performDeleteBackup(fileName)
+          },
+        })
+      }
+    } catch (error) {
+      console.error('Failed to delete backup:', error)
+      triggerFeedback('error')
+      setOperationFeedback({
+        kind: 'error',
+        message: t('backup.deleteFailMessage'),
+        actionLabel: t('common.retry'),
+        onAction: () => {
+          void performDeleteBackup(fileName)
+        },
+      })
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   const handleDeleteBackup = async (fileName: string) => {
@@ -166,26 +289,8 @@ export const BackupManager: React.FC = () => {
         {
           text: t('common.delete'),
           style: 'destructive',
-          onPress: async () => {
-            try {
-              setIsLoading(true)
-              const success = await deleteBackup(fileName)
-
-              if (success) {
-                Alert.alert(t('backup.deleteSuccessTitle'), t('backup.deleteSuccessMessage'), [
-                  { text: t('common.ok') },
-                ])
-                await loadBackupData()
-              } else {
-                Alert.alert(t('backup.deleteFailTitle'), t('backup.deleteFailMessage'), [
-                  { text: t('common.ok') },
-                ])
-              }
-            } catch (error) {
-              console.error('Failed to delete backup:', error)
-            } finally {
-              setIsLoading(false)
-            }
+          onPress: () => {
+            void performDeleteBackup(fileName)
           },
         },
       ]
@@ -212,11 +317,21 @@ export const BackupManager: React.FC = () => {
 
   return (
     <ScrollView className="flex-1 p-4 bg-white">
-
-
       {error && (
         <View className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
           <Text className="text-red-800">{error}</Text>
+        </View>
+      )}
+
+      {operationFeedback && (
+        <View className="mb-4">
+          <OperationFeedback
+            kind={operationFeedback.kind}
+            message={operationFeedback.message}
+            actionLabel={operationFeedback.actionLabel}
+            onAction={operationFeedback.onAction}
+            testID="backup-operation-feedback"
+          />
         </View>
       )}
 
@@ -229,6 +344,7 @@ export const BackupManager: React.FC = () => {
             onPress={handleCreateBackup}
             disabled={isLoading}
             className="w-full"
+            testID="backup-create-button"
           >
             <Text className="text-white font-medium">
               {isLoading ? t('backup.creating') : t('backup.create')}
@@ -240,6 +356,7 @@ export const BackupManager: React.FC = () => {
             disabled={isLoading}
             variant="outline"
             className="w-full"
+            testID="backup-export-button"
           >
             <Text className="font-medium">
               {isLoading ? t('backup.exporting') : t('backup.export')}
@@ -251,6 +368,7 @@ export const BackupManager: React.FC = () => {
             disabled={isLoading}
             variant="outline"
             className="w-full"
+            testID="backup-import-button"
           >
             <Text className="font-medium">
               {isLoading ? t('backup.importing') : t('backup.import')}

--- a/src/components/JournalInput.tsx
+++ b/src/components/JournalInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useCallback, useState, useEffect, useRef } from 'react'
 import { TextInput } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { Box } from '@/components/ui/box'
@@ -6,6 +6,8 @@ import { Text } from '@/components/ui/text'
 import { VStack } from '@/components/ui/vstack'
 import { HStack } from '@/components/ui/hstack'
 import { IconSymbol } from '@/components/ui/icon-symbol'
+import { OperationFeedback } from '@/src/components/OperationFeedback'
+import { useInteractionFeedback } from '@/src/hooks/useInteractionFeedback'
 import { Entry } from '@/src/types'
 
 interface JournalInputProps {
@@ -16,6 +18,8 @@ interface JournalInputProps {
   maxLength?: number
 }
 
+type JournalSaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+
 export const JournalInput: React.FC<JournalInputProps> = ({
   date,
   entry,
@@ -24,10 +28,12 @@ export const JournalInput: React.FC<JournalInputProps> = ({
   maxLength = 1000,
 }) => {
   const { t } = useTranslation()
+  const triggerFeedback = useInteractionFeedback()
   const [text, setText] = useState(entry?.note || '')
   const [isFocused, setIsFocused] = useState(false)
-  const [isAutoSaving, setIsAutoSaving] = useState(false)
+  const [saveStatus, setSaveStatus] = useState<JournalSaveStatus>('idle')
   const [lastSaved, setLastSaved] = useState<Date | null>(null)
+  const [lastFailedText, setLastFailedText] = useState<string | null>(null)
   const [characterCount, setCharacterCount] = useState(entry?.note?.length || 0)
 
   const autoSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -37,7 +43,29 @@ export const JournalInput: React.FC<JournalInputProps> = ({
   useEffect(() => {
     setText(entry?.note || '')
     setCharacterCount(entry?.note?.length || 0)
+    setSaveStatus('idle')
+    setLastSaved(null)
+    setLastFailedText(null)
   }, [entry])
+
+  const saveJournalText = useCallback(
+    async (nextText: string) => {
+      setSaveStatus('saving')
+      setLastFailedText(null)
+
+      try {
+        await onUpdate(nextText)
+        setLastSaved(new Date())
+        setSaveStatus('saved')
+      } catch (error) {
+        console.error('Auto-save failed:', error)
+        triggerFeedback('error')
+        setLastFailedText(nextText)
+        setSaveStatus('error')
+      }
+    },
+    [onUpdate, triggerFeedback]
+  )
 
   // Auto-save functionality with debouncing
   useEffect(() => {
@@ -48,15 +76,7 @@ export const JournalInput: React.FC<JournalInputProps> = ({
     // Only auto-save if text has changed from the original entry
     if (text !== (entry?.note || '')) {
       autoSaveTimeoutRef.current = setTimeout(async () => {
-        try {
-          setIsAutoSaving(true)
-          await onUpdate(text)
-          setLastSaved(new Date())
-        } catch (error) {
-          console.error('Auto-save failed:', error)
-        } finally {
-          setIsAutoSaving(false)
-        }
+        await saveJournalText(text)
       }, 1000) // Auto-save after 1 second of inactivity
     }
 
@@ -65,13 +85,15 @@ export const JournalInput: React.FC<JournalInputProps> = ({
         clearTimeout(autoSaveTimeoutRef.current)
       }
     }
-  }, [text, entry?.note, onUpdate])
+  }, [text, entry?.note, saveJournalText])
 
   const handleTextChange = (newText: string) => {
     // Enforce character limit
     if (newText.length <= maxLength) {
       setText(newText)
       setCharacterCount(newText.length)
+      setLastFailedText(null)
+      setSaveStatus('idle')
     }
   }
 
@@ -83,7 +105,11 @@ export const JournalInput: React.FC<JournalInputProps> = ({
     setIsFocused(false)
     // Force save on blur if there are unsaved changes
     if (text !== (entry?.note || '')) {
-      onUpdate(text).catch(console.error)
+      if (autoSaveTimeoutRef.current) {
+        clearTimeout(autoSaveTimeoutRef.current)
+        autoSaveTimeoutRef.current = null
+      }
+      void saveJournalText(text)
     }
   }
 
@@ -98,10 +124,13 @@ export const JournalInput: React.FC<JournalInputProps> = ({
   }
 
   const getStatusText = () => {
-    if (isAutoSaving) {
+    if (saveStatus === 'saving') {
       return t('common.saving')
     }
-    if (lastSaved) {
+    if (saveStatus === 'error') {
+      return t('journal.saveFailed')
+    }
+    if (saveStatus === 'saved' && lastSaved) {
       const now = new Date()
       const diffMs = now.getTime() - lastSaved.getTime()
       const diffMinutes = Math.floor(diffMs / 60000)
@@ -129,7 +158,7 @@ export const JournalInput: React.FC<JournalInputProps> = ({
           {t('journal.title')}
         </Text>
         <HStack className="items-center" space="xs">
-          {isAutoSaving && (
+          {saveStatus === 'saving' && (
             <IconSymbol name="arrow.clockwise" size={16} color="#6B7280" />
           )}
           <Text className="text-sm text-gray-500">{getStatusText()}</Text>
@@ -168,6 +197,28 @@ export const JournalInput: React.FC<JournalInputProps> = ({
           }}
         />
       </Box>
+
+      {saveStatus !== 'idle' && (
+        <OperationFeedback
+          kind={
+            saveStatus === 'error'
+              ? 'error'
+              : saveStatus === 'saving'
+              ? 'saving'
+              : 'success'
+          }
+          message={getStatusText()}
+          actionLabel={saveStatus === 'error' ? t('common.retry') : undefined}
+          onAction={
+            saveStatus === 'error'
+              ? () => {
+                  void saveJournalText(lastFailedText ?? text)
+                }
+              : undefined
+          }
+          testID="journal-save-feedback"
+        />
+      )}
 
       {/* Footer with character count and hints */}
       <HStack className="items-center justify-between">

--- a/src/components/JournalInput.tsx
+++ b/src/components/JournalInput.tsx
@@ -37,10 +37,12 @@ export const JournalInput: React.FC<JournalInputProps> = ({
   const [characterCount, setCharacterCount] = useState(entry?.note?.length || 0)
 
   const autoSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const saveRequestIdRef = useRef(0)
   const textInputRef = useRef<TextInput>(null)
 
   // Update local state when entry prop changes (e.g., date change)
   useEffect(() => {
+    saveRequestIdRef.current += 1
     setText(entry?.note || '')
     setCharacterCount(entry?.note?.length || 0)
     setSaveStatus('idle')
@@ -50,14 +52,17 @@ export const JournalInput: React.FC<JournalInputProps> = ({
 
   const saveJournalText = useCallback(
     async (nextText: string) => {
+      const requestId = ++saveRequestIdRef.current
       setSaveStatus('saving')
       setLastFailedText(null)
 
       try {
         await onUpdate(nextText)
+        if (requestId !== saveRequestIdRef.current) return
         setLastSaved(new Date())
         setSaveStatus('saved')
       } catch (error) {
+        if (requestId !== saveRequestIdRef.current) return
         console.error('Auto-save failed:', error)
         triggerFeedback('error')
         setLastFailedText(nextText)
@@ -90,6 +95,7 @@ export const JournalInput: React.FC<JournalInputProps> = ({
   const handleTextChange = (newText: string) => {
     // Enforce character limit
     if (newText.length <= maxLength) {
+      saveRequestIdRef.current += 1
       setText(newText)
       setCharacterCount(newText.length)
       setLastFailedText(null)

--- a/src/components/OperationFeedback.tsx
+++ b/src/components/OperationFeedback.tsx
@@ -93,7 +93,7 @@ export function OperationFeedback({
           <AppPressable
             onPress={onAction}
             feedback="select"
-            className={`rounded-md px-3 py-2 ${styles.action}`}
+            className={`min-h-[44px] justify-center rounded-md px-3 py-2 ${styles.action}`}
             pressedClassName={styles.actionPressed}
             testID={`${testID}-action`}
             accessibilityRole="button"

--- a/src/components/OperationFeedback.tsx
+++ b/src/components/OperationFeedback.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { Box } from '@/components/ui/box'
+import { Text } from '@/components/ui/text'
+import { HStack } from '@/components/ui/hstack'
+import { IconSymbol } from '@/components/ui/icon-symbol'
+import { AppPressable } from '@/src/components/AppPressable'
+
+export type OperationFeedbackKind = 'saving' | 'success' | 'error' | 'info'
+
+interface OperationFeedbackProps {
+  kind: OperationFeedbackKind
+  message: string
+  actionLabel?: string
+  onAction?: () => void
+  testID?: string
+}
+
+const FEEDBACK_STYLES: Record<
+  OperationFeedbackKind,
+  {
+    container: string
+    text: string
+    action: string
+    actionPressed: string
+    icon: React.ComponentProps<typeof IconSymbol>['name']
+    iconColor: string
+  }
+> = {
+  saving: {
+    container: 'bg-blue-50 border-blue-200',
+    text: 'text-blue-700',
+    action: 'bg-blue-100',
+    actionPressed: 'bg-blue-200',
+    icon: 'arrow.clockwise',
+    iconColor: '#1D4ED8',
+  },
+  success: {
+    container: 'bg-green-50 border-green-200',
+    text: 'text-green-700',
+    action: 'bg-green-100',
+    actionPressed: 'bg-green-200',
+    icon: 'checkmark.circle.fill',
+    iconColor: '#15803D',
+  },
+  error: {
+    container: 'bg-red-50 border-red-200',
+    text: 'text-red-700',
+    action: 'bg-red-100',
+    actionPressed: 'bg-red-200',
+    icon: 'exclamationmark.triangle.fill',
+    iconColor: '#B91C1C',
+  },
+  info: {
+    container: 'bg-gray-50 border-gray-200',
+    text: 'text-gray-700',
+    action: 'bg-gray-100',
+    actionPressed: 'bg-gray-200',
+    icon: 'info.circle.fill',
+    iconColor: '#4B5563',
+  },
+}
+
+/**
+ * Shows a consistent inline status banner for recoverable app operations.
+ * @param props - Feedback kind, message, and optional recovery action.
+ * @returns A compact feedback banner that can sit near the affected control.
+ * @example
+ * <OperationFeedback kind="error" message="Save failed" actionLabel="Retry" onAction={retrySave} />
+ */
+export function OperationFeedback({
+  actionLabel,
+  kind,
+  message,
+  onAction,
+  testID = 'operation-feedback',
+}: OperationFeedbackProps) {
+  const styles = FEEDBACK_STYLES[kind]
+  const hasAction = Boolean(actionLabel && onAction)
+
+  return (
+    <Box
+      accessibilityLiveRegion="polite"
+      className={`rounded-lg border p-3 ${styles.container}`}
+      testID={testID}
+    >
+      <HStack className="items-center justify-between" space="sm">
+        <HStack className="flex-1 items-center" space="sm">
+          <IconSymbol name={styles.icon} size={16} color={styles.iconColor} />
+          <Text className={`flex-1 text-sm ${styles.text}`}>{message}</Text>
+        </HStack>
+
+        {hasAction && (
+          <AppPressable
+            onPress={onAction}
+            feedback="select"
+            className={`rounded-md px-3 py-2 ${styles.action}`}
+            pressedClassName={styles.actionPressed}
+            testID={`${testID}-action`}
+            accessibilityRole="button"
+          >
+            <Text className={`text-sm font-semibold ${styles.text}`}>
+              {actionLabel}
+            </Text>
+          </AppPressable>
+        )}
+      </HStack>
+    </Box>
+  )
+}

--- a/src/components/PresetTaskEditor.tsx
+++ b/src/components/PresetTaskEditor.tsx
@@ -7,6 +7,10 @@ import { Pressable } from '@/components/ui/pressable'
 import { HStack } from '@/components/ui/hstack'
 import { VStack } from '@/components/ui/vstack'
 import { IconSymbol } from '@/components/ui/icon-symbol'
+import {
+  OperationFeedback,
+  OperationFeedbackKind,
+} from '@/src/components/OperationFeedback'
 import { Task, Category } from '@/src/types'
 import { getCategoryDisplayName } from '@/src/i18n/config'
 
@@ -28,6 +32,13 @@ interface EditingTask {
   isNew?: boolean
 }
 
+interface PresetEditorFeedback {
+  kind: OperationFeedbackKind
+  message: string
+  actionLabel?: string
+  onAction?: () => void
+}
+
 export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
   isVisible,
   tasks,
@@ -41,10 +52,13 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
   const [isLoading, setSaving] = useState(false)
   const [newCategoryName, setNewCategoryName] = useState('')
   const [showNewCategoryInput, setShowNewCategoryInput] = useState(false)
+  const [operationFeedback, setOperationFeedback] =
+    useState<PresetEditorFeedback | null>(null)
 
   // Initialize editing tasks when modal opens
   useEffect(() => {
     if (isVisible) {
+      setOperationFeedback(null)
       setEditingTasks(
         tasks.map((task) => ({
           id: task.id,
@@ -88,6 +102,7 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
   }
 
   const updateTask = (index: number, updates: Partial<EditingTask>) => {
+    setOperationFeedback(null)
     setEditingTasks((prev) =>
       prev.map((task, i) => (i === index ? { ...task, ...updates } : task))
     )
@@ -115,8 +130,19 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
       await onCreateCategory(newCategoryName.trim())
       setNewCategoryName('')
       setShowNewCategoryInput(false)
+      setOperationFeedback({
+        kind: 'success',
+        message: t('presetEditor.categoryCreated'),
+      })
     } catch {
-      Alert.alert(t('common.error'), t('presetEditor.createCategoryFailed'))
+      setOperationFeedback({
+        kind: 'error',
+        message: t('presetEditor.createCategoryFailed'),
+        actionLabel: t('common.retry'),
+        onAction: () => {
+          void handleCreateCategory()
+        },
+      })
     }
   }
 
@@ -125,7 +151,10 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
     const validTasks = editingTasks.filter((task) => task.title.trim() !== '')
 
     if (validTasks.length === 0) {
-      Alert.alert(t('common.error'), t('presetEditor.atLeastOneTask'))
+      setOperationFeedback({
+        kind: 'error',
+        message: t('presetEditor.atLeastOneTask'),
+      })
       return
     }
 
@@ -139,11 +168,18 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
     })
 
     if (duplicates.length > 0) {
-      Alert.alert(t('common.error'), t('presetEditor.duplicateTaskInCategory'))
+      setOperationFeedback({
+        kind: 'error',
+        message: t('presetEditor.duplicateTaskInCategory'),
+      })
       return
     }
 
     setSaving(true)
+    setOperationFeedback({
+      kind: 'saving',
+      message: t('common.saving'),
+    })
     try {
       // Convert editing tasks back to Task objects
       const tasksToSave: Task[] = validTasks.map((task) => ({
@@ -161,8 +197,19 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
       }))
 
       await onSave(tasksToSave)
+      setOperationFeedback({
+        kind: 'success',
+        message: t('presetEditor.saveSuccess'),
+      })
     } catch {
-      Alert.alert(t('common.error'), t('presetEditor.saveFailed'))
+      setOperationFeedback({
+        kind: 'error',
+        message: t('presetEditor.saveFailed'),
+        actionLabel: t('common.retry'),
+        onAction: () => {
+          void handleSave()
+        },
+      })
     } finally {
       setSaving(false)
     }
@@ -218,6 +265,16 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
               <Text className="text-white font-medium">{t('presetEditor.addTask')}</Text>
             </HStack>
           </Pressable>
+
+          {operationFeedback && (
+            <OperationFeedback
+              kind={operationFeedback.kind}
+              message={operationFeedback.message}
+              actionLabel={operationFeedback.actionLabel}
+              onAction={operationFeedback.onAction}
+              testID="preset-editor-feedback"
+            />
+          )}
         </VStack>
 
         {/* Task List */}

--- a/src/components/__tests__/BackupManager.test.tsx
+++ b/src/components/__tests__/BackupManager.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { Alert } from 'react-native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import { BackupManager } from '../BackupManager'
+
+const mockUseAppStore = jest.fn()
+
+jest.mock('@/components/ui/button', () => {
+  return {
+    Button: 'Button',
+  }
+})
+
+jest.mock('../../stores/app-store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    mockUseAppStore(selector),
+}))
+
+describe('BackupManager', () => {
+  const store = {
+    createBackup: jest.fn(),
+    exportData: jest.fn(),
+    importBackup: jest.fn(),
+    listBackups: jest.fn(),
+    deleteBackup: jest.fn(),
+    getBackupStats: jest.fn(),
+    error: null,
+    clearError: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(Alert, 'alert')
+    store.listBackups.mockResolvedValue([])
+    store.getBackupStats.mockResolvedValue({
+      totalBackups: 0,
+      totalSize: 0,
+      validBackups: 0,
+    })
+    mockUseAppStore.mockImplementation((selector) =>
+      typeof selector === 'function' ? selector(store) : store
+    )
+  })
+
+  it('shows inline success feedback instead of a blocking alert after creating a backup', async () => {
+    // Arrange
+    store.createBackup.mockResolvedValue({
+      success: true,
+      fileName: 'engage-backup.json',
+      size: 2048,
+      errors: [],
+    })
+    const { getByTestId } = render(<BackupManager />)
+
+    // Act
+    fireEvent.press(getByTestId('backup-create-button'))
+
+    // Assert
+    await waitFor(() => {
+      expect(store.createBackup).toHaveBeenCalledTimes(1)
+    })
+    expect(getByTestId('backup-operation-feedback')).toBeTruthy()
+    expect(Alert.alert).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/__tests__/BackupManager.test.tsx
+++ b/src/components/__tests__/BackupManager.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Alert } from 'react-native'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
-import { BackupManager } from '../BackupManager'
+import { BackupManager } from '@/src/components/BackupManager'
 
 const mockUseAppStore = jest.fn()
 

--- a/src/components/__tests__/JournalInput.test.tsx
+++ b/src/components/__tests__/JournalInput.test.tsx
@@ -152,4 +152,34 @@ describe('JournalInput', () => {
       expect(mockOnUpdate).toHaveBeenCalledWith('自動保存テスト')
     })
   })
+
+  it('shows retry feedback when journal persistence fails', async () => {
+    // Arrange
+    const failingOnUpdate = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Save failed'))
+      .mockResolvedValueOnce(undefined)
+    const { getByTestId } = render(
+      <JournalInput {...defaultProps} onUpdate={failingOnUpdate} />
+    )
+
+    // Act
+    const textInput = getByTestId('journal-text-input')
+    fireEvent.changeText(textInput, '保存に失敗するテキスト')
+    fireEvent(textInput, 'blur')
+
+    // Assert
+    await waitFor(() => {
+      expect(getByTestId('journal-save-feedback')).toBeTruthy()
+    })
+
+    fireEvent.press(getByTestId('journal-save-feedback-action'))
+
+    await waitFor(() => {
+      expect(failingOnUpdate).toHaveBeenCalledTimes(2)
+    })
+    expect(failingOnUpdate).toHaveBeenLastCalledWith(
+      '保存に失敗するテキスト'
+    )
+  })
 })

--- a/src/components/__tests__/OperationFeedback.test.tsx
+++ b/src/components/__tests__/OperationFeedback.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react-native'
-import { OperationFeedback } from '../OperationFeedback'
+import { OperationFeedback } from '@/src/components/OperationFeedback'
 
 describe('OperationFeedback', () => {
   it('shows the feedback message and retry action for recoverable failures', () => {

--- a/src/components/__tests__/OperationFeedback.test.tsx
+++ b/src/components/__tests__/OperationFeedback.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react-native'
+import { OperationFeedback } from '../OperationFeedback'
+
+describe('OperationFeedback', () => {
+  it('shows the feedback message and retry action for recoverable failures', () => {
+    // Arrange
+    const onRetry = jest.fn()
+
+    const { getByTestId, getByText } = render(
+      <OperationFeedback
+        kind="error"
+        message="Save failed"
+        actionLabel="Retry"
+        onAction={onRetry}
+        testID="save-feedback"
+      />
+    )
+
+    // Act
+    fireEvent.press(getByTestId('save-feedback-action'))
+
+    // Assert
+    expect(getByText('Save failed')).toBeTruthy()
+    expect(getByText('Retry')).toBeTruthy()
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/__tests__/PresetTaskEditor.test.tsx
+++ b/src/components/__tests__/PresetTaskEditor.test.tsx
@@ -101,7 +101,9 @@ describe('PresetTaskEditor', () => {
   })
 
   it('allows changing task category', () => {
-    const { getByTestId } = render(<PresetTaskEditor {...defaultProps} />)
+    const { getByTestId } = render(
+      <PresetTaskEditor {...defaultProps} />
+    )
 
     // Find category option for the first task (index 0)
     const categoryOption = getByTestId('category-option-life-0')
@@ -147,7 +149,7 @@ describe('PresetTaskEditor', () => {
   })
 
   it('validates tasks before saving', async () => {
-    const { getByTestId, getByDisplayValue } = render(
+    const { getByTestId, getByDisplayValue, getByText } = render(
       <PresetTaskEditor {...defaultProps} />
     )
 
@@ -163,17 +165,15 @@ describe('PresetTaskEditor', () => {
     fireEvent.press(saveButton)
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith(
-        'エラー',
-        '少なくとも1つのタスクが必要です'
-      )
+      expect(getByTestId('preset-editor-feedback')).toBeTruthy()
     })
 
+    expect(getByText('presetEditor.atLeastOneTask')).toBeTruthy()
     expect(mockOnSave).not.toHaveBeenCalled()
   })
 
   it('detects duplicate task names in same category', async () => {
-    const { getByTestId, getByDisplayValue } = render(
+    const { getByTestId, getByDisplayValue, getByText } = render(
       <PresetTaskEditor {...defaultProps} />
     )
 
@@ -190,19 +190,19 @@ describe('PresetTaskEditor', () => {
     fireEvent.press(saveButton)
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith(
-        'エラー',
-        '同じカテゴリー内で重複するタスク名があります'
-      )
+      expect(getByTestId('preset-editor-feedback')).toBeTruthy()
     })
 
+    expect(getByText('presetEditor.duplicateTaskInCategory')).toBeTruthy()
     expect(mockOnSave).not.toHaveBeenCalled()
   })
 
   it('saves valid tasks successfully', async () => {
     mockOnSave.mockResolvedValue(undefined)
 
-    const { getByTestId } = render(<PresetTaskEditor {...defaultProps} />)
+    const { getByTestId } = render(
+      <PresetTaskEditor {...defaultProps} />
+    )
 
     const saveButton = getByTestId('preset-editor-save')
     fireEvent.press(saveButton)
@@ -240,16 +240,22 @@ describe('PresetTaskEditor', () => {
   it('handles save errors gracefully', async () => {
     mockOnSave.mockRejectedValue(new Error('Save failed'))
 
-    const { getByTestId } = render(<PresetTaskEditor {...defaultProps} />)
+    const { getByTestId, getByText } = render(
+      <PresetTaskEditor {...defaultProps} />
+    )
 
     const saveButton = getByTestId('preset-editor-save')
     fireEvent.press(saveButton)
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith(
-        'エラー',
-        'タスクの保存に失敗しました'
-      )
+      expect(getByTestId('preset-editor-feedback')).toBeTruthy()
+    })
+    expect(getByText('presetEditor.saveFailed')).toBeTruthy()
+
+    fireEvent.press(getByTestId('preset-editor-feedback-action'))
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -258,7 +264,7 @@ describe('PresetTaskEditor', () => {
       new Error('Category creation failed')
     )
 
-    const { getByTestId, getByPlaceholderText } = render(
+    const { getByTestId, getByPlaceholderText, getByText } = render(
       <PresetTaskEditor {...defaultProps} />
     )
 
@@ -267,7 +273,9 @@ describe('PresetTaskEditor', () => {
     fireEvent.press(addCategoryButton)
 
     // Enter category name
-    const categoryInput = getByPlaceholderText('新しいカテゴリー名')
+    const categoryInput = getByPlaceholderText(
+      'presetEditor.newCategoryPlaceholder'
+    )
     fireEvent.changeText(categoryInput, '勉強')
 
     // Try to create category
@@ -275,10 +283,8 @@ describe('PresetTaskEditor', () => {
     fireEvent.press(createButton)
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith(
-        'エラー',
-        'カテゴリーの作成に失敗しました'
-      )
+      expect(getByTestId('preset-editor-feedback')).toBeTruthy()
     })
+    expect(getByText('presetEditor.createCategoryFailed')).toBeTruthy()
   })
 })

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -20,6 +20,7 @@ const en = {
     continue: 'Continue',
     next: 'Next',
     skip: 'Skip',
+    retry: 'Retry',
   },
 
   calendar: {
@@ -91,6 +92,8 @@ const en = {
     atLeastOneTask: 'At least one task is required',
     duplicateTaskInCategory: 'Duplicate task names in the same category',
     saveFailed: 'Failed to save tasks',
+    saveSuccess: 'Preset tasks saved',
+    categoryCreated: 'Category created',
   },
 
   stats: {
@@ -186,6 +189,7 @@ const en = {
     export: 'Export & Share Data',
     importing: 'Importing...',
     import: 'Import Backup',
+    deleting: 'Deleting...',
     statistics: 'Backup Statistics',
     totalBackups: 'Total backups:',
     validBackups: 'Valid backups:',
@@ -201,6 +205,8 @@ const en = {
     createSuccessTitle: 'Backup Created',
     createSuccessMessage:
       'Backup created successfully.\n\nFile: {{fileName}}\nSize: {{size}}',
+    createSuccessMessageInline:
+      'Backup created: {{fileName}} ({{size}})',
     createFailTitle: 'Backup Failed',
     exportSuccessTitle: 'Export Complete',
     exportSuccessMessage: 'Data exported and shared successfully.',
@@ -210,6 +216,7 @@ const en = {
       'This will replace all current data. Continue?',
     importSuccessTitle: 'Import Complete',
     importSuccessMessage: 'Data imported successfully.\n\nCategories: {{categories}}\nTasks: {{tasks}}\nEntries: {{entries}}\nCompletions: {{completions}}\nSettings: {{settings}}',
+    importSuccessMessageInline: 'Imported data: {{categories}} categories, {{tasks}} tasks, {{entries}} entries, {{completions}} completions, {{settings}} settings.',
     importFailTitle: 'Import Failed',
     deleteConfirmTitle: 'Delete Backup',
     deleteConfirmMessage: 'Delete backup file "{{fileName}}"?',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -20,6 +20,7 @@ const ja = {
     continue: '続行',
     next: '次へ',
     skip: 'スキップ',
+    retry: '再試行',
   },
 
   calendar: {
@@ -91,6 +92,8 @@ const ja = {
     atLeastOneTask: '少なくとも1つのタスクが必要です',
     duplicateTaskInCategory: '同じカテゴリー内で重複するタスク名があります',
     saveFailed: 'タスクの保存に失敗しました',
+    saveSuccess: 'プリセットタスクを保存しました',
+    categoryCreated: 'カテゴリーを作成しました',
   },
 
   stats: {
@@ -186,6 +189,7 @@ const ja = {
     export: 'データをエクスポート・共有',
     importing: 'インポート中...',
     import: 'バックアップをインポート',
+    deleting: '削除中...',
     statistics: 'バックアップ統計',
     totalBackups: '総バックアップ数:',
     validBackups: '有効なバックアップ:',
@@ -201,6 +205,8 @@ const ja = {
     createSuccessTitle: 'バックアップ作成完了',
     createSuccessMessage:
       'バックアップが正常に作成されました。\n\nファイル名: {{fileName}}\nサイズ: {{size}}',
+    createSuccessMessageInline:
+      'バックアップを作成しました: {{fileName}} ({{size}})',
     createFailTitle: 'バックアップ作成失敗',
     exportSuccessTitle: 'データエクスポート完了',
     exportSuccessMessage:
@@ -211,6 +217,7 @@ const ja = {
       'この操作により、現在のデータがすべて置き換えられます。続行しますか？',
     importSuccessTitle: 'インポート完了',
     importSuccessMessage: 'データが正常にインポートされました。\n\nカテゴリ: {{categories}}\nタスク: {{tasks}}\nエントリ: {{entries}}\n完了記録: {{completions}}\n設定: {{settings}}',
+    importSuccessMessageInline: 'データをインポートしました: カテゴリ {{categories}}件、タスク {{tasks}}件、エントリ {{entries}}件、完了記録 {{completions}}件、設定 {{settings}}件。',
     importFailTitle: 'インポート失敗',
     deleteConfirmTitle: 'バックアップ削除',
     deleteConfirmMessage:


### PR DESCRIPTION
## Summary
- Add a shared OperationFeedback inline banner for saving, success, error, and retry states.
- Move Journal autosave failures, Backup routine success/failure, and Preset editor validation/save/category failures away from blocking alerts.
- Keep destructive confirmations for import/delete/discard flows, and update the Backup Maestro flow to assert inline success feedback.

## Validation
- pnpm typecheck
- pnpm lint
- pnpm exec jest --runInBand
- pnpm exec jest --runInBand --runTestsByPath src/components/__tests__/JournalInput.test.tsx --testPathIgnorePatterns='^$' -t 'retry feedback'
- pnpm exec jest --runInBand --runTestsByPath src/components/__tests__/PresetTaskEditor.test.tsx --testPathIgnorePatterns='^$' -t 'validates tasks|duplicate task|save errors|category creation errors'
- pnpm build:e2e
- pnpm test:e2e:production:single maestro/ios/05-journal-entry.yaml
- pnpm test:e2e:production:single maestro/ios/07-edit-presets.yaml
- pnpm test:e2e:production:single maestro/ios/11-backup-create.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline operation feedback UI added across backups, presets, and journal saves (saving/success/error) with retry actions
  * New status indicators and localized success messages for backup create/import and category actions
  * Expanded icon set to improve visual consistency

* **Tests**
  * Added tests covering feedback UI, backup flows, journal save retry, and preset editor feedback behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/Engage/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->