### PR TITLE
UX: add Today completion closure feedback

### DIFF
--- a/maestro/ios/04-task-completion.yaml
+++ b/maestro/ios/04-task-completion.yaml
@@ -52,3 +52,7 @@ tags:
 # Verify completion counter changes to 1/1
 - assertVisible:
     text: "1/1"
+
+# Verify final-task completion shows a closure message
+- assertVisible:
+    text: "All tasks complete. Nice closure for today."

--- a/maestro/ios/04-task-completion.yaml
+++ b/maestro/ios/04-task-completion.yaml
@@ -54,5 +54,7 @@ tags:
     text: "1/1"
 
 # Verify final-task completion shows a closure message
-- assertVisible:
-    text: "All tasks complete. Nice closure for today."
+- extendedWaitUntil:
+    visible:
+      text: "All tasks complete. Nice closure for today."
+    timeout: 15000

--- a/src/components/DaySheet.tsx
+++ b/src/components/DaySheet.tsx
@@ -33,7 +33,7 @@ interface DaySheetProps {
 }
 
 type DaySheetTaskFeedback = {
-  kind: 'completed' | 'undone' | 'error'
+  kind: 'completed' | 'undone' | 'allCompleted' | 'error'
   taskId: string
   title: string
 }
@@ -131,9 +131,25 @@ export const DaySheet: React.FC<DaySheetProps> = ({
         const result = await onTaskToggle(task.id)
 
         if (result.success) {
+          const nextCompletedTaskIds = new Set(completedTaskIds)
+
+          if (result.change === 'completed') {
+            nextCompletedTaskIds.add(task.id)
+          } else {
+            nextCompletedTaskIds.delete(task.id)
+          }
+
+          // Give the final completion a distinct closure moment.
+          const completesVisibleTasks =
+            result.change === 'completed' &&
+            tasks.length > 0 &&
+            tasks.every((visibleTask) =>
+              nextCompletedTaskIds.has(visibleTask.id)
+            )
+
           showTaskFeedback(
             {
-              kind: result.change,
+              kind: completesVisibleTasks ? 'allCompleted' : result.change,
               taskId: task.id,
               title: task.title,
             },
@@ -167,7 +183,7 @@ export const DaySheet: React.FC<DaySheetProps> = ({
         setPendingTaskId(null)
       }
     },
-    [onTaskToggle, showTaskFeedback, triggerFeedback]
+    [completedTaskIds, onTaskToggle, showTaskFeedback, tasks, triggerFeedback]
   )
 
   // Calculate progress for each category
@@ -259,6 +275,8 @@ export const DaySheet: React.FC<DaySheetProps> = ({
                     t('daySheet.taskCompleted', {
                       title: taskFeedback.title,
                     })}
+                  {taskFeedback.kind === 'allCompleted' &&
+                    t('daySheet.allTasksCompleted')}
                   {taskFeedback.kind === 'undone' &&
                     t('daySheet.taskCompletionUndone', {
                       title: taskFeedback.title,
@@ -384,6 +402,9 @@ export const DaySheet: React.FC<DaySheetProps> = ({
             </VStack>
           ) : (
             <Box className="p-8 items-center">
+              <Text className="text-lg font-semibold text-gray-800 text-center mb-2">
+                {t('daySheet.noTasksTitle')}
+              </Text>
               <Text className="text-gray-500 text-center mb-4">
                 {t('daySheet.noTasksMessage')}
               </Text>

--- a/src/components/__tests__/DaySheet.test.tsx
+++ b/src/components/__tests__/DaySheet.test.tsx
@@ -30,6 +30,16 @@ describe('DaySheet', () => {
     },
   ]
 
+  const secondTask: Task = {
+    id: 'task2',
+    title: '提案メモを書く',
+    categoryId: 'business',
+    defaultMinutes: 15,
+    archived: false,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+
   const mockEntry: Entry = {
     id: 'entry1',
     date: '2025-01-15',
@@ -82,6 +92,7 @@ describe('DaySheet', () => {
     )
 
     // Assert
+    expect(getByText('daySheet.noTasksTitle')).toBeTruthy()
     expect(getByText('daySheet.noTasksMessage')).toBeTruthy()
     fireEvent.press(getByTestId('empty-task-selection-button'))
     expect(mockOnTaskSelectionPress).toHaveBeenCalledTimes(1)
@@ -101,7 +112,9 @@ describe('DaySheet', () => {
 
   it('shows completion acknowledgement after a task is completed', async () => {
     // Arrange
-    const { getByTestId, getByText } = render(<DaySheet {...defaultProps} />)
+    const { getByTestId, getByText } = render(
+      <DaySheet {...defaultProps} tasks={[...mockTasks, secondTask]} />
+    )
 
     // Act
     fireEvent.press(getByTestId('task-item-task1'))
@@ -109,6 +122,31 @@ describe('DaySheet', () => {
     // Assert
     await waitFor(() => {
       expect(getByText('daySheet.taskCompleted')).toBeTruthy()
+    })
+  })
+
+  it('shows closure feedback when the final assigned task is completed', async () => {
+    // Arrange
+    mockOnTaskToggle.mockResolvedValue({
+      success: true,
+      date: '2025-01-15',
+      taskId: 'task2',
+      change: 'completed',
+    })
+    const { getByTestId, getByText } = render(
+      <DaySheet
+        {...defaultProps}
+        tasks={[...mockTasks, secondTask]}
+        completions={completedCompletions}
+      />
+    )
+
+    // Act
+    fireEvent.press(getByTestId('task-item-task2'))
+
+    // Assert
+    await waitFor(() => {
+      expect(getByText('daySheet.allTasksCompleted')).toBeTruthy()
     })
   })
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -44,9 +44,11 @@ const en = {
 
   daySheet: {
     selectTasks: 'Select Tasks',
-    noTasksMessage: 'Select tasks to display',
+    noTasksTitle: 'No habits selected yet',
+    noTasksMessage: 'Choose one habit to start today.',
     chooseTodaysHabits: "Choose today's habits",
     taskCompleted: '"{{title}}" completed',
+    allTasksCompleted: 'All tasks complete. Nice closure for today.',
     taskCompletionUndone: '"{{title}}" marked incomplete',
     taskCompletionFailed: 'Failed to save task completion',
     retry: 'Retry',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -44,9 +44,11 @@ const ja = {
 
   daySheet: {
     selectTasks: '表示するタスクを選択',
-    noTasksMessage: '表示するタスクを選択してください',
+    noTasksTitle: '今日の習慣が未選択です',
+    noTasksMessage: 'まずは1つ、今日取り組む習慣を選びましょう。',
     chooseTodaysHabits: '今日の習慣を選ぶ',
     taskCompleted: '「{{title}}」を完了しました',
+    allTasksCompleted: '今日のタスクをすべて完了しました。お疲れさまです。',
     taskCompletionUndone: '「{{title}}」を未完了に戻しました',
     taskCompletionFailed: 'タスクの保存に失敗しました',
     retry: '再試行',


### PR DESCRIPTION
## Summary
- Add a distinct all-completed closure message after the final visible Today task is completed
- Improve first-run Today empty copy with a clear title and action-oriented message
- Extend the DaySheet unit coverage and Maestro task-completion flow for the new closure feedback

## Validation
- pnpm typecheck
- pnpm lint
- pnpm exec jest --runInBand src/components/__tests__/DaySheet.test.tsx
- pnpm exec jest --runInBand
- pnpm test:e2e:production:single maestro/ios/03-task-selection.yaml
- pnpm test:e2e:production:single maestro/ios/04-task-completion.yaml
- git diff --check
- /Users/ryotamurakami/gstack/bin/gstack-review-read => NO_REVIEWS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a final completion message when all visible daily tasks are finished and updates completion feedback when the last task is toggled.

* **UI**
  * Enhanced empty-task state with a new title and clearer guidance to help you pick and start a habit.

* **Localization**
  * Updated English and Japanese strings to support the new messages and empty-state UI.

* **Tests**
  * End-to-end QA updated to verify the completion/closure message appears.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/Engage/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->