### PR TITLE
UX: add notification permission state recovery

### DIFF
--- a/maestro/ios/09-settings.yaml
+++ b/maestro/ios/09-settings.yaml
@@ -39,6 +39,28 @@ tags:
 - assertVisible:
     id: "settings-backup"
 
+# Open notification settings and verify the permission-state surface
+- tapOn:
+    id: "settings-notifications"
+
+- extendedWaitUntil:
+    visible:
+      text: "Daily Reminder"
+    timeout: 5000
+
+- assertVisible:
+    text: "Notification Status"
+- assertVisible:
+    id: "notification-check-permission"
+
+- tapOn:
+    id: "notification-done"
+
+- extendedWaitUntil:
+    visible:
+      text: "Settings"
+    timeout: 5000
+
 # Close settings
 - tapOn:
     id: "settings-close"

--- a/maestro/ios/09-settings.yaml
+++ b/maestro/ios/09-settings.yaml
@@ -45,13 +45,17 @@ tags:
 
 - extendedWaitUntil:
     visible:
-      text: "Daily Reminder"
-    timeout: 5000
+      id: "notification-reminder-switch"
+    timeout: 15000
 
-- assertVisible:
-    text: "Notification Status"
-- assertVisible:
-    id: "notification-check-permission"
+- extendedWaitUntil:
+    visible:
+      id: "notification-state-not-determined"
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "notification-check-permission"
+    timeout: 15000
 
 - tapOn:
     id: "notification-done"

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -52,6 +52,7 @@ jest.mock('react-native', () => {
     TextInput: createNativeComponent('TextInput'),
     SafeAreaView: createNativeComponent('SafeAreaView'),
     ScrollView: createNativeComponent('ScrollView'),
+    Switch: createNativeComponent('Switch'),
     Pressable,
     Modal,
     Platform: {
@@ -74,6 +75,9 @@ jest.mock('react-native', () => {
     },
     Share: {
       share: jest.fn(),
+    },
+    Linking: {
+      openSettings: jest.fn(() => Promise.resolve()),
     },
   }
 })
@@ -102,6 +106,38 @@ jest.mock('expo-haptics', () => ({
   },
   ImpactFeedbackStyle: {
     Light: 'light',
+  },
+}))
+
+// Mock expo-notifications module
+jest.mock('expo-notifications', () => ({
+  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
+  getAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve([])),
+  getPermissionsAsync: jest.fn(() =>
+    Promise.resolve({ status: 'undetermined', granted: false })
+  ),
+  requestPermissionsAsync: jest.fn(() =>
+    Promise.resolve({ status: 'denied', granted: false })
+  ),
+  scheduleNotificationAsync: jest.fn(() =>
+    Promise.resolve('engage-daily-reminder')
+  ),
+  setNotificationHandler: jest.fn(),
+  IosAuthorizationStatus: {
+    NOT_DETERMINED: 0,
+    DENIED: 1,
+    AUTHORIZED: 2,
+    PROVISIONAL: 3,
+    EPHEMERAL: 4,
+  },
+  SchedulableTriggerInputTypes: {
+    CALENDAR: 'calendar',
+    DAILY: 'daily',
+    WEEKLY: 'weekly',
+    MONTHLY: 'monthly',
+    YEARLY: 'yearly',
+    DATE: 'date',
+    TIME_INTERVAL: 'timeInterval',
   },
 }))
 

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -1,72 +1,204 @@
-import React, { useState } from 'react'
-import { View, Text, Switch, Alert, Platform } from 'react-native'
+import React, { useEffect, useMemo, useState } from 'react'
+import { ScrollView, Switch, Text, View } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { VStack } from '@/components/ui/vstack'
 import { HStack } from '@/components/ui/hstack'
-import { Button } from '@/components/ui/button'
+import { AppPressable } from '@/src/components/AppPressable'
+import {
+  DEFAULT_REMINDER_HOUR,
+  DEFAULT_REMINDER_MINUTE,
+  NOTIFICATION_TIME_PRESETS,
+  TIME_PART_PAD_LENGTH,
+} from '@/src/constants/notifications'
 import { useNotifications } from '@/src/hooks/useNotifications'
 
 interface NotificationSettingsProps {
   onClose?: () => void
 }
 
+type NotificationStatusTone = 'neutral' | 'warning' | 'success' | 'scheduled'
+
+interface NotificationStatusView {
+  titleKey: string
+  bodyKey: string
+  tone: NotificationStatusTone
+  testID: string
+}
+
+/**
+ * Formats a reminder time for labels and confirmation text.
+ * @param hour - The 24-hour clock hour.
+ * @param minute - The minute within the hour.
+ * @returns A `H:MM` time string.
+ * @example
+ * formatTime(9, 0) // => "9:00"
+ */
+const formatTime = (hour: number, minute: number): string => {
+  return `${hour}:${minute.toString().padStart(TIME_PART_PAD_LENGTH, '0')}`
+}
+
+/**
+ * Builds the status panel copy from permission and schedule state.
+ * @param settings - The current notification permission and schedule state.
+ * @returns Copy keys, visual tone, and test ID for the state panel.
+ * @example
+ * getNotificationStatusView({ permissionStatus: 'denied', isScheduled: false, ... }) // => denied view
+ */
+const getNotificationStatusView = (
+  settings: ReturnType<typeof useNotifications>['settings']
+): NotificationStatusView => {
+  if (settings.permissionStatus === 'denied') {
+    return {
+      titleKey: 'notifications.permissionDeniedTitle',
+      bodyKey: 'notifications.permissionDeniedBody',
+      tone: 'warning',
+      testID: 'notification-state-denied',
+    }
+  }
+
+  if (settings.permissionStatus === 'notDetermined') {
+    return {
+      titleKey: 'notifications.permissionNotDeterminedTitle',
+      bodyKey: 'notifications.permissionNotDeterminedBody',
+      tone: 'neutral',
+      testID: 'notification-state-not-determined',
+    }
+  }
+
+  if (settings.isScheduled) {
+    return {
+      titleKey: 'notifications.reminderScheduledTitle',
+      bodyKey: 'notifications.reminderScheduledBody',
+      tone: 'scheduled',
+      testID: 'notification-state-scheduled',
+    }
+  }
+
+  return {
+    titleKey: 'notifications.permissionEnabledTitle',
+    bodyKey: 'notifications.permissionEnabledBody',
+    tone: 'success',
+    testID: 'notification-state-enabled',
+  }
+}
+
+const statusToneClassNames: Record<NotificationStatusTone, string> = {
+  neutral: 'bg-gray-50 border-gray-200',
+  warning: 'bg-red-50 border-system-red',
+  success: 'bg-blue-50 border-system-blue',
+  scheduled: 'bg-green-50 border-system-green',
+}
+
+/**
+ * Renders reminder permission recovery, schedule state, and daily reminder controls.
+ * @param props - Optional close callback supplied by the Settings modal.
+ * @returns A notification settings screen with explicit permission and schedule states.
+ * @example
+ * <NotificationSettings onClose={goBackToSettingsMenu} />
+ */
 export function NotificationSettings({ onClose }: NotificationSettingsProps) {
   const { t } = useTranslation()
   const {
     settings,
     isLoading,
+    errorMessage,
     requestPermissions,
     scheduleDailyReminder,
     cancelDailyReminder,
     refreshSettings,
+    openNotificationSettings,
   } = useNotifications()
 
   const [reminderTime, setReminderTime] = useState({
-    hour: settings.dailyReminderTime?.hour ?? 9,
-    minute: settings.dailyReminderTime?.minute ?? 0,
+    hour: settings.dailyReminderTime?.hour ?? DEFAULT_REMINDER_HOUR,
+    minute: settings.dailyReminderTime?.minute ?? DEFAULT_REMINDER_MINUTE,
   })
+  const [operationMessage, setOperationMessage] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const statusView = useMemo(
+    () => getNotificationStatusView(settings),
+    [settings]
+  )
+  const isDenied = settings.permissionStatus === 'denied'
+  const canEditReminder = settings.permissionStatus === 'enabled'
 
-  const handleEnableNotifications = async () => {
-    if (!settings.enabled) {
-      const granted = await requestPermissions()
-      if (granted) {
-        // Schedule default daily reminder
-        await scheduleDailyReminder(reminderTime.hour, reminderTime.minute)
-        Alert.alert(
-          t('notifications.enabledTitle'),
-          t('notifications.enabledMessage', { time: formatTime(reminderTime.hour, reminderTime.minute) })
-        )
-      } else {
-        Alert.alert(
-          t('notifications.permissionRequired'),
-          Platform.OS === 'ios'
-            ? t('notifications.permissionIOS')
-            : t('notifications.permissionAndroid')
-        )
+  useEffect(() => {
+    if (settings.dailyReminderTime) {
+      setReminderTime(settings.dailyReminderTime)
+    }
+  }, [settings.dailyReminderTime])
+
+  const handleEnableReminder = async (): Promise<void> => {
+    setIsSaving(true)
+    setOperationMessage(null)
+
+    try {
+      const hasPermission =
+        settings.permissionStatus === 'enabled' || (await requestPermissions())
+
+      if (!hasPermission) {
+        setOperationMessage('notifications.permissionStillNeeded')
+        return
       }
-    } else {
-      // Disable notifications
+
+      const didSchedule = await scheduleDailyReminder(
+        reminderTime.hour,
+        reminderTime.minute
+      )
+      setOperationMessage(
+        didSchedule
+          ? 'notifications.reminderEnabledInline'
+          : 'notifications.scheduleFailed'
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleReminderToggle = async (nextEnabled: boolean): Promise<void> => {
+    if (isDenied || isSaving) {
+      return
+    }
+
+    if (nextEnabled) {
+      await handleEnableReminder()
+      return
+    }
+
+    setIsSaving(true)
+    setOperationMessage(null)
+
+    try {
       await cancelDailyReminder()
-      Alert.alert(
-        t('notifications.disabledTitle'),
-        t('notifications.disabledMessage')
-      )
+      setOperationMessage('notifications.reminderDisabledInline')
+    } finally {
+      setIsSaving(false)
     }
   }
 
-  const handleTimeChange = async (hour: number, minute: number) => {
+  const handleTimeChange = async (
+    hour: number,
+    minute: number
+  ): Promise<void> => {
     setReminderTime({ hour, minute })
-    if (settings.enabled) {
-      await scheduleDailyReminder(hour, minute)
-      Alert.alert(
-        t('notifications.timeUpdatedTitle'),
-        t('notifications.timeUpdatedMessage', { time: formatTime(hour, minute) })
-      )
-    }
-  }
 
-  const formatTime = (hour: number, minute: number) => {
-    return `${hour}:${minute.toString().padStart(2, '0')}`
+    if (!canEditReminder || isSaving) {
+      return
+    }
+
+    setIsSaving(true)
+    setOperationMessage(null)
+
+    try {
+      const didSchedule = await scheduleDailyReminder(hour, minute)
+      setOperationMessage(
+        didSchedule
+          ? 'notifications.timeUpdatedInline'
+          : 'notifications.scheduleFailed'
+      )
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   if (isLoading) {
@@ -78,124 +210,205 @@ export function NotificationSettings({ onClose }: NotificationSettingsProps) {
   }
 
   return (
-    <VStack className="flex-1 p-6 bg-white">
-      {/* Enable/Disable Notifications */}
-      <VStack className="mb-8">
-        <HStack className="justify-between items-center mb-4">
-          <VStack className="flex-1">
-            <Text className="text-lg font-semibold text-gray-900">
-              {t('notifications.dailyReminder')}
-            </Text>
-            <Text className="text-sm text-gray-600">
-              {t('notifications.dailyReminderDescription')}
-            </Text>
-          </VStack>
-          <Switch
-            value={settings.enabled}
-            onValueChange={handleEnableNotifications}
-            trackColor={{ false: '#E5E7EB', true: '#007AFF' }}
-            thumbColor={settings.enabled ? '#FFFFFF' : '#9CA3AF'}
-          />
-        </HStack>
+    <ScrollView className="flex-1 bg-white">
+      <VStack className="p-6">
+        <VStack className="mb-6">
+          <HStack className="justify-between items-center mb-4">
+            <VStack className="flex-1 mr-4">
+              <Text className="text-lg font-semibold text-gray-900">
+                {t('notifications.dailyReminder')}
+              </Text>
+              <Text className="text-sm text-gray-600">
+                {t('notifications.dailyReminderDescription')}
+              </Text>
+            </VStack>
+            <Switch
+              value={settings.enabled}
+              onValueChange={handleReminderToggle}
+              disabled={isDenied || isSaving}
+              testID="notification-reminder-switch"
+              trackColor={{ false: '#E5E7EB', true: '#007AFF' }}
+              thumbColor={settings.enabled ? '#FFFFFF' : '#9CA3AF'}
+              accessibilityHint={
+                isDenied
+                  ? t('notifications.controlsDisabledDenied')
+                  : t('notifications.toggleReminderHint')
+              }
+            />
+          </HStack>
 
-        {settings.enabled && (
-          <VStack className="ml-4 pl-4 border-l-2 border-gray-200">
-            <Text className="text-sm text-gray-600 mb-2">
-              {t('notifications.currentTime')}{' '}
-              {settings.dailyReminderTime
+          {isDenied && (
+            <Text
+              className="text-sm text-gray-700"
+              testID="notification-disabled-reason"
+            >
+              {t('notifications.controlsDisabledDenied')}
+            </Text>
+          )}
+        </VStack>
+
+        <VStack
+          className={`mb-6 p-4 rounded-lg border ${statusToneClassNames[statusView.tone]}`}
+          testID={statusView.testID}
+        >
+          <Text className="text-sm font-semibold text-gray-900 mb-1">
+            {t(statusView.titleKey)}
+          </Text>
+          <Text className="text-sm text-gray-700">
+            {t(statusView.bodyKey, {
+              time: settings.dailyReminderTime
                 ? formatTime(
                     settings.dailyReminderTime.hour,
                     settings.dailyReminderTime.minute
                   )
-                : t('notifications.notSet')}
-            </Text>
+                : formatTime(reminderTime.hour, reminderTime.minute),
+            })}
+          </Text>
+        </VStack>
 
-            {/* Time Selection Buttons */}
+        {canEditReminder && (
+          <VStack className="mb-6">
             <Text className="text-sm font-medium text-gray-700 mb-2">
-              {t('notifications.selectTime')}
+              {settings.isScheduled
+                ? t('notifications.currentTimeWithValue', {
+                    time: settings.dailyReminderTime
+                      ? formatTime(
+                          settings.dailyReminderTime.hour,
+                          settings.dailyReminderTime.minute
+                        )
+                      : t('notifications.notSet'),
+                  })
+                : t('notifications.selectTime')}
             </Text>
             <VStack className="gap-2">
-              {[
-                { hour: 8, minute: 0, label: t('notifications.morning8') },
-                { hour: 9, minute: 0, label: t('notifications.morning9') },
-                { hour: 12, minute: 0, label: t('notifications.noon') },
-                { hour: 18, minute: 0, label: t('notifications.evening6') },
-                { hour: 20, minute: 0, label: t('notifications.night8') },
-              ].map((time) => (
-                <Button
-                  key={`${time.hour}-${time.minute}`}
-                  variant={
-                    settings.dailyReminderTime?.hour === time.hour &&
-                    settings.dailyReminderTime?.minute === time.minute
-                      ? 'solid'
-                      : 'outline'
-                  }
-                  size="sm"
-                  onPress={() => handleTimeChange(time.hour, time.minute)}
-                  className="justify-start"
-                >
-                  <Text
-                    className={
-                      settings.dailyReminderTime?.hour === time.hour &&
-                      settings.dailyReminderTime?.minute === time.minute
-                        ? 'text-white'
-                        : 'text-gray-700'
-                    }
+              {NOTIFICATION_TIME_PRESETS.map((time) => {
+                const isSelected =
+                  settings.dailyReminderTime?.hour === time.hour &&
+                  settings.dailyReminderTime?.minute === time.minute
+
+                return (
+                  <AppPressable
+                    key={`${time.hour}-${time.minute}`}
+                    onPress={() => handleTimeChange(time.hour, time.minute)}
+                    selected={isSelected}
+                    disabled={isSaving}
+                    feedback="select"
+                    className={`
+                      rounded-lg border px-4 py-3 touch-target-minimum
+                      ${
+                        isSelected
+                          ? 'bg-system-blue border-system-blue'
+                          : 'bg-white border-gray-300'
+                      }
+                    `}
+                    pressedClassName="bg-system-gray-6"
+                    testID={`notification-time-${time.hour}-${time.minute}`}
+                    accessibilityRole="button"
                   >
-                    {time.label}
-                  </Text>
-                </Button>
-              ))}
+                    <Text
+                      className={
+                        isSelected
+                          ? 'text-white font-semibold'
+                          : 'text-gray-700 font-medium'
+                      }
+                    >
+                      {t(time.labelKey)}
+                    </Text>
+                  </AppPressable>
+                )
+              })}
             </VStack>
           </VStack>
         )}
-      </VStack>
 
-      {/* Notification Status */}
-      <VStack className="mb-8 p-4 bg-gray-50 rounded-lg">
-        <Text className="text-sm font-medium text-gray-700 mb-2">
-          {t('notifications.status')}
-        </Text>
-        <HStack className="justify-between items-center mb-1">
-          <Text className="text-sm text-gray-600">{t('notifications.permissionState')}</Text>
+        <VStack className="mb-6 p-4 bg-gray-50 rounded-lg">
+          <Text className="text-sm font-medium text-gray-700 mb-2">
+            {t('notifications.status')}
+          </Text>
+          <HStack className="justify-between items-center mb-1">
+            <Text className="text-sm text-gray-600">
+              {t('notifications.permissionState')}
+            </Text>
+            <Text className="text-sm font-medium text-gray-900">
+              {t(`notifications.permission.${settings.permissionStatus}`)}
+            </Text>
+          </HStack>
+          <HStack className="justify-between items-center">
+            <Text className="text-sm text-gray-600">
+              {t('notifications.scheduledNotifications')}
+            </Text>
+            <Text className="text-sm font-medium text-gray-900">
+              {t('notifications.countUnit', { count: settings.scheduledCount })}
+            </Text>
+          </HStack>
+        </VStack>
+
+        {(operationMessage || errorMessage) && (
           <Text
-            className={`text-sm font-medium ${
-              settings.enabled ? 'text-green-600' : 'text-red-600'
-            }`}
+            className="mb-4 text-sm font-medium text-gray-800"
+            testID="notification-operation-message"
           >
-            {settings.enabled ? t('notifications.enabled') : t('notifications.disabled')}
+            {t(operationMessage || errorMessage || '')}
           </Text>
-        </HStack>
-        <HStack className="justify-between items-center">
-          <Text className="text-sm text-gray-600">{t('notifications.scheduledNotifications')}</Text>
-          <Text className="text-sm font-medium text-gray-900">
-            {t('notifications.countUnit', { count: settings.scheduledCount })}
-          </Text>
-        </HStack>
-      </VStack>
-
-      {/* Action Buttons */}
-      <VStack className="gap-3">
-        <Button variant="outline" onPress={refreshSettings} className="w-full">
-          <Text className="text-gray-700">{t('notifications.refresh')}</Text>
-        </Button>
-
-        {onClose && (
-          <Button variant="solid" onPress={onClose} className="w-full">
-            <Text className="text-white">{t('common.done')}</Text>
-          </Button>
         )}
-      </VStack>
 
-      {/* Help Text */}
-      <VStack className="mt-6 p-4 bg-blue-50 rounded-lg">
-        <Text className="text-sm text-blue-800 font-medium mb-1">
-          {t('notifications.tipTitle')}
-        </Text>
-        <Text className="text-sm text-blue-700">
-          {t('notifications.tipBody')}
-        </Text>
+        <VStack className="gap-3">
+          {isDenied && (
+            <AppPressable
+              onPress={openNotificationSettings}
+              disabled={isSaving}
+              feedback="select"
+              className="w-full bg-system-blue rounded-lg py-3 touch-target-minimum"
+              pressedClassName="bg-business-dark"
+              testID="notification-open-settings"
+              accessibilityRole="button"
+            >
+              <Text className="text-white font-medium text-center">
+                {t('notifications.openSettings')}
+              </Text>
+            </AppPressable>
+          )}
+
+          <AppPressable
+            onPress={refreshSettings}
+            disabled={isSaving}
+            feedback="select"
+            className="w-full bg-secondary-system-background rounded-lg py-3 touch-target-minimum"
+            pressedClassName="bg-system-gray-5"
+            testID="notification-check-permission"
+            accessibilityRole="button"
+          >
+            <Text className="text-gray-700 font-medium text-center">
+              {t('notifications.checkPermissionAgain')}
+            </Text>
+          </AppPressable>
+
+          {onClose && (
+            <AppPressable
+              onPress={onClose}
+              disabled={isSaving}
+              feedback="select"
+              className="w-full bg-system-blue rounded-lg py-3 touch-target-minimum"
+              pressedClassName="bg-business-dark"
+              testID="notification-done"
+              accessibilityRole="button"
+            >
+              <Text className="text-white font-medium text-center">
+                {t('common.done')}
+              </Text>
+            </AppPressable>
+          )}
+        </VStack>
+
+        <VStack className="mt-6 p-4 bg-blue-50 rounded-lg">
+          <Text className="text-sm text-blue-800 font-medium mb-1">
+            {t('notifications.tipTitle')}
+          </Text>
+          <Text className="text-sm text-blue-700">
+            {t('notifications.tipBody')}
+          </Text>
+        </VStack>
       </VStack>
-    </VStack>
+    </ScrollView>
   )
 }

--- a/src/components/__tests__/NotificationSettings.test.tsx
+++ b/src/components/__tests__/NotificationSettings.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react-native'
+import { NotificationSettings } from '../NotificationSettings'
+
+const mockOpenNotificationSettings = jest.fn()
+const mockRefreshSettings = jest.fn()
+const mockUseNotifications = jest.fn()
+
+jest.mock('@/src/hooks/useNotifications', () => ({
+  useNotifications: () => mockUseNotifications(),
+}))
+
+jest.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: jest.fn(),
+  },
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number; time?: string }) => {
+      const translations: Record<string, string> = {
+        'common.done': 'Done',
+        'common.loading': 'Loading',
+        'notifications.checkPermissionAgain': 'Check permission again',
+        'notifications.controlsDisabledDenied':
+          'Reminder controls are disabled because notification permission is blocked.',
+        'notifications.dailyReminder': 'Daily Reminder',
+        'notifications.dailyReminderDescription':
+          'Get daily habit check reminders at a set time',
+        'notifications.openSettings': 'Open Settings',
+        'notifications.permissionDeniedBody':
+          'Notifications are blocked in system settings. Open Settings to allow reminders again.',
+        'notifications.permissionDeniedTitle': 'Notifications blocked',
+        'notifications.permissionEnabledBody':
+          'Choose a reminder time to schedule your daily habit prompt.',
+        'notifications.permissionEnabledTitle': 'Notifications allowed',
+        'notifications.permissionState': 'Permission:',
+        'notifications.permission.denied': 'Denied',
+        'notifications.permission.enabled': 'Allowed',
+        'notifications.permission.notDetermined': 'Not requested',
+        'notifications.permissionNotDeterminedBody':
+          'Turn on reminders to choose a time and allow Engage to send daily habit prompts.',
+        'notifications.permissionNotDeterminedTitle':
+          'Permission not requested',
+        'notifications.reminderScheduledTitle': 'Reminder scheduled',
+        'notifications.scheduledNotifications': 'Scheduled:',
+        'notifications.selectTime': 'Select reminder time:',
+        'notifications.status': 'Notification Status',
+        'notifications.tipBody': 'Notifications help you return to tasks.',
+        'notifications.tipTitle': 'Tip',
+        'notifications.toggleReminderHint': 'Turn daily reminders on or off.',
+      }
+
+      if (key === 'notifications.countUnit') {
+        return `${options?.count ?? 0}`
+      }
+
+      if (key === 'notifications.currentTimeWithValue') {
+        return `Current time: ${options?.time ?? ''}`
+      }
+
+      if (key === 'notifications.reminderScheduledBody') {
+        return `Your daily reminder is scheduled for ${options?.time ?? ''}.`
+      }
+
+      return translations[key] || key
+    },
+    i18n: { changeLanguage: jest.fn() },
+  }),
+}))
+
+const createHookState = (
+  overrides: Partial<ReturnType<typeof mockUseNotifications>> = {}
+) => ({
+  cancelDailyReminder: jest.fn(),
+  errorMessage: null,
+  isLoading: false,
+  openNotificationSettings: mockOpenNotificationSettings,
+  refreshSettings: mockRefreshSettings,
+  requestPermissions: jest.fn(),
+  scheduleDailyReminder: jest.fn(),
+  settings: {
+    dailyReminderTime: null,
+    enabled: false,
+    isScheduled: false,
+    permissionStatus: 'notDetermined',
+    scheduledCount: 0,
+  },
+  ...overrides,
+})
+
+describe('NotificationSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseNotifications.mockReturnValue(createHookState())
+  })
+
+  it('shows not-requested permission state with a renamed check action', () => {
+    // Arrange & Act
+    const { getByText, queryByText } = render(<NotificationSettings />)
+
+    // Assert
+    expect(getByText('Permission not requested')).toBeTruthy()
+    expect(getByText('Check permission again')).toBeTruthy()
+    expect(queryByText('Refresh Settings')).toBeNull()
+  })
+
+  it('shows Open Settings as the primary recovery when permission is denied', () => {
+    // Arrange
+    mockUseNotifications.mockReturnValue(
+      createHookState({
+        settings: {
+          dailyReminderTime: null,
+          enabled: false,
+          isScheduled: false,
+          permissionStatus: 'denied',
+          scheduledCount: 0,
+        },
+      })
+    )
+    const { getByTestId, getByText } = render(<NotificationSettings />)
+
+    // Act
+    fireEvent.press(getByTestId('notification-open-settings'))
+
+    // Assert
+    expect(getByText('Notifications blocked')).toBeTruthy()
+    expect(getByText('Open Settings')).toBeTruthy()
+    expect(getByText(
+      'Reminder controls are disabled because notification permission is blocked.'
+    )).toBeTruthy()
+    expect(getByTestId('notification-reminder-switch').props.disabled).toBe(
+      true
+    )
+    expect(mockOpenNotificationSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows enabled permission state before a reminder is scheduled', () => {
+    // Arrange
+    mockUseNotifications.mockReturnValue(
+      createHookState({
+        settings: {
+          dailyReminderTime: null,
+          enabled: false,
+          isScheduled: false,
+          permissionStatus: 'enabled',
+          scheduledCount: 0,
+        },
+      })
+    )
+
+    // Act
+    const { getByTestId, getByText } = render(<NotificationSettings />)
+
+    // Assert
+    expect(getByText('Notifications allowed')).toBeTruthy()
+    expect(getByText('Select reminder time:')).toBeTruthy()
+    expect(getByTestId('notification-state-enabled')).toBeTruthy()
+  })
+
+  it('shows scheduled reminder state with the current time', () => {
+    // Arrange
+    mockUseNotifications.mockReturnValue(
+      createHookState({
+        settings: {
+          dailyReminderTime: { hour: 20, minute: 0 },
+          enabled: true,
+          isScheduled: true,
+          permissionStatus: 'enabled',
+          scheduledCount: 1,
+        },
+      })
+    )
+
+    // Act
+    const { getByTestId, getByText } = render(<NotificationSettings />)
+
+    // Assert
+    expect(getByText('Reminder scheduled')).toBeTruthy()
+    expect(getByText('Your daily reminder is scheduled for 20:00.')).toBeTruthy()
+    expect(getByText('Current time: 20:00')).toBeTruthy()
+    expect(getByTestId('notification-state-scheduled')).toBeTruthy()
+  })
+})

--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -1,0 +1,12 @@
+export const DAILY_REMINDER_NOTIFICATION_ID = 'engage-daily-reminder'
+export const DEFAULT_REMINDER_HOUR = 9
+export const DEFAULT_REMINDER_MINUTE = 0
+export const TIME_PART_PAD_LENGTH = 2
+
+export const NOTIFICATION_TIME_PRESETS = [
+  { hour: 8, minute: 0, labelKey: 'notifications.morning8' },
+  { hour: 9, minute: 0, labelKey: 'notifications.morning9' },
+  { hour: 12, minute: 0, labelKey: 'notifications.noon' },
+  { hour: 18, minute: 0, labelKey: 'notifications.evening6' },
+  { hour: 20, minute: 0, labelKey: 'notifications.night8' },
+] as const

--- a/src/hooks/__tests__/useNotifications.test.ts
+++ b/src/hooks/__tests__/useNotifications.test.ts
@@ -1,0 +1,156 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+import * as Notifications from 'expo-notifications'
+import {
+  DAILY_REMINDER_NOTIFICATION_ID,
+  DEFAULT_REMINDER_HOUR,
+} from '@/src/constants/notifications'
+import {
+  getNotificationPermissionState,
+  getReminderTimeFromTrigger,
+  useNotifications,
+} from '../useNotifications'
+
+const permissionStatuses = {
+  denied: 'denied' as Notifications.NotificationPermissionsStatus['status'],
+  granted: 'granted' as Notifications.NotificationPermissionsStatus['status'],
+  undetermined:
+    'undetermined' as Notifications.NotificationPermissionsStatus['status'],
+}
+
+const createPermissionResponse = (
+  status: Notifications.NotificationPermissionsStatus['status'],
+  granted: boolean
+): Notifications.NotificationPermissionsStatus => ({
+  status,
+  granted,
+  canAskAgain: status !== permissionStatuses.denied,
+  expires: 'never',
+})
+
+const createDailyReminder = (
+  hour: number,
+  minute: number
+): Notifications.NotificationRequest => ({
+  identifier: DAILY_REMINDER_NOTIFICATION_ID,
+  content: {
+    title: 'Engage',
+    body: "Time to check today's habits.",
+    data: { type: 'dailyReminder' },
+    sound: null,
+    subtitle: null,
+    categoryIdentifier: null,
+  },
+  trigger: {
+    type: Notifications.SchedulableTriggerInputTypes.DAILY,
+    hour,
+    minute,
+  },
+})
+
+describe('notification permission helpers', () => {
+  it('maps Expo permission responses to user-facing states', () => {
+    // Arrange
+    const grantedPermission = createPermissionResponse(
+      permissionStatuses.granted,
+      true
+    )
+    const deniedPermission = createPermissionResponse(
+      permissionStatuses.denied,
+      false
+    )
+    const undeterminedPermission = createPermissionResponse(
+      permissionStatuses.undetermined,
+      false
+    )
+
+    // Act & Assert
+    expect(getNotificationPermissionState(grantedPermission)).toBe('enabled')
+    expect(getNotificationPermissionState(deniedPermission)).toBe('denied')
+    expect(getNotificationPermissionState(undeterminedPermission)).toBe(
+      'notDetermined'
+    )
+  })
+
+  it('reads the reminder time from a daily trigger', () => {
+    // Arrange
+    const trigger: Notifications.NotificationTrigger = {
+      type: Notifications.SchedulableTriggerInputTypes.DAILY,
+      hour: DEFAULT_REMINDER_HOUR,
+      minute: 30,
+    }
+
+    // Act & Assert
+    expect(getReminderTimeFromTrigger(trigger)).toEqual({
+      hour: DEFAULT_REMINDER_HOUR,
+      minute: 30,
+    })
+  })
+})
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue(
+      createPermissionResponse(permissionStatuses.undetermined, false)
+    )
+    ;(
+      Notifications.getAllScheduledNotificationsAsync as jest.Mock
+    ).mockResolvedValue([])
+  })
+
+  it('loads enabled scheduled reminder state from Expo', async () => {
+    // Arrange
+    ;(Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue(
+      createPermissionResponse(permissionStatuses.granted, true)
+    )
+    ;(
+      Notifications.getAllScheduledNotificationsAsync as jest.Mock
+    ).mockResolvedValue([createDailyReminder(9, 0)])
+
+    // Act
+    const { result } = renderHook(() => useNotifications())
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.settings).toMatchObject({
+      enabled: true,
+      permissionStatus: 'enabled',
+      isScheduled: true,
+      dailyReminderTime: { hour: 9, minute: 0 },
+      scheduledCount: 1,
+    })
+  })
+
+  it('schedules a daily reminder after permission is enabled', async () => {
+    // Arrange
+    ;(Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue(
+      createPermissionResponse(permissionStatuses.granted, true)
+    )
+    const { result } = renderHook(() => useNotifications())
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    // Act
+    await act(async () => {
+      await result.current.scheduleDailyReminder(20, 0)
+    })
+
+    // Assert
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith(
+      DAILY_REMINDER_NOTIFICATION_ID
+    )
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identifier: DAILY_REMINDER_NOTIFICATION_ID,
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.DAILY,
+          hour: 20,
+          minute: 0,
+        },
+      })
+    )
+  })
+})

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,49 +1,278 @@
-/**
- * Notifications hook - Stub implementation
- * This keeps the settings screen stable until notification scheduling is wired.
- */
+import { useCallback, useEffect, useState } from 'react'
+import { Linking } from 'react-native'
+import * as Notifications from 'expo-notifications'
+import {
+  DAILY_REMINDER_NOTIFICATION_ID,
+  DEFAULT_REMINDER_HOUR,
+  DEFAULT_REMINDER_MINUTE,
+} from '@/src/constants/notifications'
 
-import { useState } from 'react'
+export type NotificationPermissionState =
+  | 'notDetermined'
+  | 'denied'
+  | 'enabled'
+
+interface ReminderTime {
+  hour: number
+  minute: number
+}
 
 interface NotificationSettings {
   enabled: boolean
-  dailyReminderTime: { hour: number; minute: number } | null
+  permissionStatus: NotificationPermissionState
+  dailyReminderTime: ReminderTime | null
   scheduledCount: number
+  isScheduled: boolean
 }
 
+const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
+  enabled: false,
+  permissionStatus: 'notDetermined',
+  dailyReminderTime: null,
+  scheduledCount: 0,
+  isScheduled: false,
+}
+
+/**
+ * Checks whether an unknown date component object has numeric reminder fields.
+ * @param value - The candidate trigger date component object.
+ * @returns `true` when the value can provide hour and minute fields.
+ * @example
+ * hasReminderTimeFields({ hour: 9, minute: 0 }) // => true
+ */
+const hasReminderTimeFields = (
+  value: unknown
+): value is { hour?: number; minute?: number } => {
+  return typeof value === 'object' && value !== null
+}
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+    shouldShowBanner: true,
+    shouldShowList: true,
+  }),
+})
+
+/**
+ * Converts Expo's platform permission response into the app's user-facing states.
+ * @param permissions - The notification permission response from Expo.
+ * @returns The permission state used by NotificationSettings UI.
+ * @example
+ * getNotificationPermissionState({ status: 'denied', granted: false } as NotificationPermissionsStatus) // => 'denied'
+ */
+export const getNotificationPermissionState = (
+  permissions: Notifications.NotificationPermissionsStatus
+): NotificationPermissionState => {
+  if (
+    permissions.granted ||
+    permissions.status === 'granted' ||
+    permissions.ios?.status === Notifications.IosAuthorizationStatus.AUTHORIZED ||
+    permissions.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL
+  ) {
+    return 'enabled'
+  }
+
+  if (
+    permissions.status === 'denied' ||
+    permissions.ios?.status === Notifications.IosAuthorizationStatus.DENIED
+  ) {
+    return 'denied'
+  }
+
+  return 'notDetermined'
+}
+
+/**
+ * Reads the reminder time from Expo's scheduled notification trigger shapes.
+ * @param trigger - The trigger attached to a scheduled notification request.
+ * @returns The hour/minute pair when the trigger is daily/calendar-based, otherwise `null`.
+ * @example
+ * getReminderTimeFromTrigger({ type: 'daily', hour: 9, minute: 0 }) // => { hour: 9, minute: 0 }
+ */
+export const getReminderTimeFromTrigger = (
+  trigger: Notifications.NotificationTrigger
+): ReminderTime | null => {
+  if (!trigger || !('type' in trigger)) {
+    return null
+  }
+
+  if (
+    trigger.type === Notifications.SchedulableTriggerInputTypes.DAILY &&
+    'hour' in trigger &&
+    'minute' in trigger &&
+    typeof trigger.hour === 'number' &&
+    typeof trigger.minute === 'number'
+  ) {
+    return { hour: trigger.hour, minute: trigger.minute }
+  }
+
+  if (trigger.type === Notifications.SchedulableTriggerInputTypes.CALENDAR) {
+    if (
+      'hour' in trigger &&
+      'minute' in trigger &&
+      typeof trigger.hour === 'number' &&
+      typeof trigger.minute === 'number'
+    ) {
+      return {
+        hour: trigger.hour,
+        minute: trigger.minute,
+      }
+    }
+
+    if (
+      'dateComponents' in trigger &&
+      hasReminderTimeFields(trigger.dateComponents)
+    ) {
+      return {
+        hour: trigger.dateComponents.hour ?? DEFAULT_REMINDER_HOUR,
+        minute: trigger.dateComponents.minute ?? DEFAULT_REMINDER_MINUTE,
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Reads and controls daily reminder notification permission and schedule state.
+ * @returns Settings plus actions used by the notification settings screen.
+ * @example
+ * const { settings, requestPermissions } = useNotifications()
+ */
 export function useNotifications() {
-  const [settings] = useState<NotificationSettings>({
-    enabled: false,
-    dailyReminderTime: null,
-    scheduledCount: 0,
-  })
+  const [settings, setSettings] = useState<NotificationSettings>(
+    DEFAULT_NOTIFICATION_SETTINGS
+  )
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const [isLoading] = useState(false)
+  const refreshSettings = useCallback(async (): Promise<void> => {
+    setIsLoading(true)
+    setErrorMessage(null)
 
-  const requestPermissions = async (): Promise<boolean> => {
-    console.warn('useNotifications: requestPermissions not implemented')
-    return false
-  }
+    try {
+      const [permissions, scheduledNotifications] = await Promise.all([
+        Notifications.getPermissionsAsync(),
+        Notifications.getAllScheduledNotificationsAsync(),
+      ])
+      const permissionStatus = getNotificationPermissionState(permissions)
+      const dailyReminder = scheduledNotifications.find(
+        (notification) =>
+          notification.identifier === DAILY_REMINDER_NOTIFICATION_ID
+      )
+      const dailyReminderTime = dailyReminder
+        ? getReminderTimeFromTrigger(dailyReminder.trigger)
+        : null
 
-  const scheduleDailyReminder = async (hour: number, minute: number): Promise<boolean> => {
-    console.warn('useNotifications: scheduleDailyReminder not implemented', { hour, minute })
-    return false
-  }
+      setSettings({
+        enabled: permissionStatus === 'enabled' && Boolean(dailyReminder),
+        permissionStatus,
+        dailyReminderTime,
+        scheduledCount: scheduledNotifications.length,
+        isScheduled: Boolean(dailyReminder),
+      })
+    } catch (error) {
+      console.error('Failed to refresh notification settings:', error)
+      setErrorMessage('notifications.settingsUnavailable')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
 
-  const cancelDailyReminder = async (): Promise<void> => {
-    console.warn('useNotifications: cancelDailyReminder not implemented')
-  }
+  useEffect(() => {
+    void refreshSettings()
+  }, [refreshSettings])
 
-  const refreshSettings = async (): Promise<void> => {
-    console.warn('useNotifications: refreshSettings not implemented')
-  }
+  const requestPermissions = useCallback(async (): Promise<boolean> => {
+    setErrorMessage(null)
+
+    try {
+      const permissions = await Notifications.requestPermissionsAsync({
+        ios: {
+          allowAlert: true,
+          allowBadge: true,
+          allowSound: true,
+        },
+      })
+      await refreshSettings()
+      return getNotificationPermissionState(permissions) === 'enabled'
+    } catch (error) {
+      console.error('Failed to request notification permissions:', error)
+      setErrorMessage('notifications.permissionRequestFailed')
+      return false
+    }
+  }, [refreshSettings])
+
+  const scheduleDailyReminder = useCallback(
+    async (hour: number, minute: number): Promise<boolean> => {
+      setErrorMessage(null)
+
+      try {
+        const permissions = await Notifications.getPermissionsAsync()
+
+        if (getNotificationPermissionState(permissions) !== 'enabled') {
+          await refreshSettings()
+          return false
+        }
+
+        // Replace the app's existing daily reminder so only one reminder is active.
+        await Notifications.cancelScheduledNotificationAsync(
+          DAILY_REMINDER_NOTIFICATION_ID
+        ).catch(() => undefined)
+        await Notifications.scheduleNotificationAsync({
+          identifier: DAILY_REMINDER_NOTIFICATION_ID,
+          content: {
+            title: 'Engage',
+            body: "Time to check today's habits.",
+            data: { type: 'dailyReminder' },
+          },
+          trigger: {
+            type: Notifications.SchedulableTriggerInputTypes.DAILY,
+            hour,
+            minute,
+          },
+        })
+        await refreshSettings()
+        return true
+      } catch (error) {
+        console.error('Failed to schedule daily reminder:', error)
+        setErrorMessage('notifications.scheduleFailed')
+        await refreshSettings()
+        return false
+      }
+    },
+    [refreshSettings]
+  )
+
+  const cancelDailyReminder = useCallback(async (): Promise<void> => {
+    setErrorMessage(null)
+
+    try {
+      await Notifications.cancelScheduledNotificationAsync(
+        DAILY_REMINDER_NOTIFICATION_ID
+      )
+      await refreshSettings()
+    } catch (error) {
+      console.error('Failed to cancel daily reminder:', error)
+      setErrorMessage('notifications.cancelFailed')
+      await refreshSettings()
+    }
+  }, [refreshSettings])
+
+  const openNotificationSettings = useCallback(async (): Promise<void> => {
+    await Linking.openSettings()
+  }, [])
 
   return {
     settings,
     isLoading,
+    errorMessage,
     requestPermissions,
     scheduleDailyReminder,
     cancelDailyReminder,
     refreshSettings,
+    openNotificationSettings,
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -160,6 +160,18 @@ const en = {
     dailyReminder: 'Daily Reminder',
     dailyReminderDescription:
       'Get daily habit check reminders at a set time',
+    permissionNotDeterminedTitle: 'Permission not requested',
+    permissionNotDeterminedBody:
+      'Turn on reminders to choose a time and allow Engage to send daily habit prompts.',
+    permissionDeniedTitle: 'Notifications blocked',
+    permissionDeniedBody:
+      'Notifications are blocked in system settings. Open Settings to allow reminders again.',
+    permissionEnabledTitle: 'Notifications allowed',
+    permissionEnabledBody:
+      'Choose a reminder time to schedule your daily habit prompt.',
+    reminderScheduledTitle: 'Reminder scheduled',
+    reminderScheduledBody:
+      'Your daily reminder is scheduled for {{time}}.',
     enabledTitle: 'Notifications Enabled',
     enabledMessage:
       'Daily reminder will be sent at {{time}}.',
@@ -168,10 +180,20 @@ const en = {
     permissionAndroid: 'Please enable notifications in app settings.',
     disabledTitle: 'Notifications Disabled',
     disabledMessage: 'Reminder has been cancelled.',
+    reminderEnabledInline: 'Daily reminder is on.',
+    reminderDisabledInline: 'Daily reminder is off.',
+    permissionStillNeeded:
+      'Notifications are still blocked. Open system settings to allow reminders.',
+    permissionRequestFailed: 'Could not request notification permission.',
+    settingsUnavailable: 'Could not read notification settings.',
+    scheduleFailed: 'Could not schedule the daily reminder.',
+    cancelFailed: 'Could not cancel the daily reminder.',
     timeUpdatedTitle: 'Time Updated',
     timeUpdatedMessage:
       'Daily reminder will be sent at {{time}}.',
+    timeUpdatedInline: 'Reminder time updated.',
     currentTime: 'Current time:',
+    currentTimeWithValue: 'Current time: {{time}}',
     notSet: 'Not set',
     selectTime: 'Select reminder time:',
     morning8: 'Morning 8:00',
@@ -181,11 +203,20 @@ const en = {
     night8: 'Night 8:00',
     status: 'Notification Status',
     permissionState: 'Permission:',
+    permission: {
+      notDetermined: 'Not requested',
+      denied: 'Denied',
+      enabled: 'Allowed',
+    },
     enabled: 'Enabled',
     disabled: 'Disabled',
     scheduledNotifications: 'Scheduled:',
     countUnit: '{{count}}',
-    refresh: 'Refresh Settings',
+    checkPermissionAgain: 'Check permission again',
+    openSettings: 'Open Settings',
+    controlsDisabledDenied:
+      'Reminder controls are disabled because notification permission is blocked.',
+    toggleReminderHint: 'Turn daily reminders on or off.',
     tipTitle: 'Tip',
     tipBody:
       'Tap a notification to go directly to your tasks. If notifications are not arriving, check that they are enabled in your device settings.',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -159,6 +159,18 @@ const ja = {
     dailyReminder: 'デイリーリマインダー',
     dailyReminderDescription:
       '毎日決まった時間に習慣チェックのリマインダーを受け取る',
+    permissionNotDeterminedTitle: '通知許可は未確認です',
+    permissionNotDeterminedBody:
+      'リマインダーをオンにすると、時刻を選んで毎日の習慣通知を許可できます。',
+    permissionDeniedTitle: '通知がブロックされています',
+    permissionDeniedBody:
+      '端末の設定で通知がブロックされています。設定を開いて通知を許可してください。',
+    permissionEnabledTitle: '通知は許可されています',
+    permissionEnabledBody:
+      'リマインダー時刻を選ぶと、毎日の習慣通知を予定できます。',
+    reminderScheduledTitle: 'リマインダー設定済み',
+    reminderScheduledBody:
+      '毎日 {{time}} にリマインダーを送信します。',
     enabledTitle: '通知が有効になりました',
     enabledMessage:
       '毎日 {{time}} にリマインダーを送信します。',
@@ -167,10 +179,20 @@ const ja = {
     permissionAndroid: 'アプリの設定から通知を有効にしてください。',
     disabledTitle: '通知が無効になりました',
     disabledMessage: 'リマインダーをキャンセルしました。',
+    reminderEnabledInline: 'デイリーリマインダーをオンにしました。',
+    reminderDisabledInline: 'デイリーリマインダーをオフにしました。',
+    permissionStillNeeded:
+      '通知がまだブロックされています。端末の設定で通知を許可してください。',
+    permissionRequestFailed: '通知許可をリクエストできませんでした。',
+    settingsUnavailable: '通知設定を読み込めませんでした。',
+    scheduleFailed: 'デイリーリマインダーを設定できませんでした。',
+    cancelFailed: 'デイリーリマインダーを解除できませんでした。',
     timeUpdatedTitle: '時間を更新しました',
     timeUpdatedMessage:
       '毎日 {{time}} にリマインダーを送信します。',
+    timeUpdatedInline: 'リマインダー時刻を更新しました。',
     currentTime: '現在の設定時間:',
+    currentTimeWithValue: '現在の設定時間: {{time}}',
     notSet: '未設定',
     selectTime: 'リマインダー時間を選択:',
     morning8: '朝 8:00',
@@ -180,11 +202,20 @@ const ja = {
     night8: '夜 8:00',
     status: '通知ステータス',
     permissionState: '許可状態:',
+    permission: {
+      notDetermined: '未確認',
+      denied: '拒否',
+      enabled: '許可済み',
+    },
     enabled: '有効',
     disabled: '無効',
     scheduledNotifications: '予定された通知:',
     countUnit: '{{count}}件',
-    refresh: '設定を更新',
+    checkPermissionAgain: '許可状態を確認',
+    openSettings: '設定を開く',
+    controlsDisabledDenied:
+      '通知許可がブロックされているため、リマインダー操作は無効です。',
+    toggleReminderHint: 'デイリーリマインダーのオン/オフを切り替えます。',
     tipTitle: 'ヒント',
     tipBody:
       '通知をタップすると、今日のタスク画面に直接移動できます。通知が届かない場合は、端末の設定で通知が許可されているか確認してください。',


### PR DESCRIPTION
## Summary
- Replace the notification hook stub with Expo Notifications permission, schedule, cancel, refresh, and Open Settings actions
- Render distinct notification states for not requested, denied, enabled, and scheduled
- Make denied recovery use Open Settings as the primary action and rename Refresh Settings to Check permission again
- Explain disabled controls when notification permission is blocked
- Add focused hook/component coverage and extend Settings Maestro smoke QA

## Planning / Docs
- Routed as the P1-B mobile UI slice from TODOS.md
- Checked Context7 `/websites/expo_dev_versions_sdk_notifications` for Expo Notifications permission and scheduling APIs

## Validation
- pnpm typecheck
- pnpm lint
- pnpm exec jest --runInBand src/hooks/__tests__/useNotifications.test.ts src/components/__tests__/NotificationSettings.test.tsx
- pnpm exec jest --runInBand
- pnpm test:e2e:production:single maestro/ios/09-settings.yaml
- git diff --check
- /Users/ryotamurakami/gstack/bin/gstack-review-read => NO_REVIEWS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned notification settings with permission-state UI, inline operation messages, and explicit enable/disable behavior.
  * Added preset time options and improved scheduling controls, plus "Check Permission Again" and "Open Settings" recovery actions.

* **Tests**
  * Added comprehensive tests for notification state, scheduling, and UI behaviors.

* **Documentation**
  * Updated English and Japanese notification-related translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/Engage/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->