### PR TITLE
feat: connect completions to stats surfaces

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -130,6 +130,15 @@ export const Calendar: React.FC<CalendarProps> = ({
       completedTasks: currentMonthDates.reduce((sum, count) => sum + count, 0),
     }
   }, [achievementData, calendarData])
+  const selectedDateIsInCurrentMonth = useMemo(() => {
+    // Hide the selected-day recap after month navigation moves that date off-screen.
+    return calendarData.some((week) =>
+      week.some(
+        (day) => day.isCurrentMonth && day.dateString === selectedDate
+      )
+    )
+  }, [calendarData, selectedDate])
+  const selectedDateCompletionCount = achievementData[selectedDate] || 0
 
   const getHeatmapColor = (completionCount: number): string => {
     if (completionCount === 0) return 'bg-gray-100'
@@ -316,25 +325,49 @@ export const Calendar: React.FC<CalendarProps> = ({
       </HStack>
 
       <Box className="mx-4 mt-6 rounded-2xl border border-blue-100 bg-blue-50 px-4 py-4">
-        <HStack className="items-center justify-between">
-          <VStack space="xs">
-            <Text className="text-xs font-semibold uppercase text-blue-500">
-              {t('calendar.monthlySummary')}
+        <VStack space="sm">
+          <HStack className="items-center justify-between">
+            <VStack space="xs">
+              <Text className="text-xs font-semibold uppercase text-blue-500">
+                {t('calendar.monthlySummary')}
+              </Text>
+              <Text className="text-sm font-medium text-gray-700">
+                {monthlySummary.completedTasks > 0
+                  ? t('calendar.monthlySummaryCompleted', {
+                      count: monthlySummary.completedTasks,
+                    })
+                  : t('calendar.monthlySummaryEmpty')}
+              </Text>
+            </VStack>
+            <Text className="text-sm font-semibold text-blue-700">
+              {t('calendar.monthlySummaryActiveDays', {
+                count: monthlySummary.activeDays,
+              })}
             </Text>
-            <Text className="text-sm font-medium text-gray-700">
-              {monthlySummary.completedTasks > 0
-                ? t('calendar.monthlySummaryCompleted', {
-                    count: monthlySummary.completedTasks,
-                  })
-                : t('calendar.monthlySummaryEmpty')}
-            </Text>
-          </VStack>
-          <Text className="text-sm font-semibold text-blue-700">
-            {t('calendar.monthlySummaryActiveDays', {
-              count: monthlySummary.activeDays,
-            })}
+          </HStack>
+
+          <Text
+            className="text-xs leading-5 text-blue-700"
+            testID="calendar-monthly-summary-hint"
+          >
+            {monthlySummary.completedTasks > 0
+              ? t('calendar.monthlySummaryHint')
+              : t('calendar.monthlySummaryEmptyHint')}
           </Text>
-        </HStack>
+
+          {selectedDateIsInCurrentMonth && selectedDateCompletionCount > 0 && (
+            <Box
+              className="rounded-xl border border-green-200 bg-green-50 px-3 py-2"
+              testID="calendar-selected-day-recap"
+            >
+              <Text className="text-xs font-medium text-green-700">
+                {t('calendar.selectedDateCompleted', {
+                  count: selectedDateCompletionCount,
+                })}
+              </Text>
+            </Box>
+          )}
+        </VStack>
       </Box>
     </Box>
   )

--- a/src/components/Statistics.tsx
+++ b/src/components/Statistics.tsx
@@ -25,6 +25,7 @@ export const Statistics: React.FC<StatisticsProps> = ({
   const [selectedPeriod, setSelectedPeriod] = useState<'week' | 'month'>('week')
 
   const currentStats = selectedPeriod === 'week' ? weeklyStats : monthlyStats
+  const hasPeriodCompletions = currentStats.totalTasks > 0
 
   // Get category color
   const getCategoryColor = (categoryId: string) => {
@@ -164,6 +165,20 @@ export const Statistics: React.FC<StatisticsProps> = ({
             </HStack>
           </VStack>
 
+          <Box
+            className="rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3"
+            testID="stats-period-recap"
+          >
+            <Text className="text-sm font-medium leading-5 text-blue-700">
+              {hasPeriodCompletions
+                ? t('stats.periodRecap', {
+                    count: currentStats.totalTasks,
+                    days: currentStats.activeDays,
+                  })
+                : t('stats.periodEmptyNextAction')}
+            </Text>
+          </Box>
+
           {/* Today's Achievements */}
           <VStack space="sm">
             <Text className="text-xl font-semibold text-gray-800">
@@ -268,7 +283,9 @@ export const Statistics: React.FC<StatisticsProps> = ({
                               className={`w-4 h-4 rounded-full ${categoryColor}`}
                             />
                             <Text className="font-medium text-gray-800">
-                              {category ? getCategoryDisplayName(category) : 'Unknown Category'}
+                              {category
+                                ? getCategoryDisplayName(category)
+                                : t('stats.unknownCategory')}
                             </Text>
                           </HStack>
                           <Text className="text-sm text-gray-600">

--- a/src/components/__tests__/Calendar.causality.test.tsx
+++ b/src/components/__tests__/Calendar.causality.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react-native'
+import { Calendar } from '../Calendar'
+
+describe('Calendar completion causality', () => {
+  it('guides users to complete a Today habit when the month has no completions', () => {
+    // Arrange
+    const { getByTestId, getByText, queryByTestId } = render(
+      <Calendar
+        achievementData={{}}
+        onDateSelect={jest.fn()}
+        selectedDate="2026-05-15"
+      />
+    )
+
+    // Assert
+    expect(getByTestId('calendar-monthly-summary-hint')).toBeTruthy()
+    expect(getByText('calendar.monthlySummaryEmptyHint')).toBeTruthy()
+    expect(queryByTestId('calendar-selected-day-recap')).toBeNull()
+  })
+
+  it('recaps completions for the selected date when the heatmap updates', () => {
+    // Arrange
+    const { getByTestId, getByText } = render(
+      <Calendar
+        achievementData={{ '2026-05-15': 2 }}
+        onDateSelect={jest.fn()}
+        selectedDate="2026-05-15"
+      />
+    )
+
+    // Assert
+    expect(getByTestId('calendar-selected-day-recap')).toBeTruthy()
+    expect(getByText('calendar.selectedDateCompleted')).toBeTruthy()
+  })
+
+  it('hides the selected-day recap when month navigation leaves that date behind', () => {
+    // Arrange
+    const { getByTestId, queryByTestId } = render(
+      <Calendar
+        achievementData={{ '2026-05-15': 2 }}
+        onDateSelect={jest.fn()}
+        selectedDate="2026-05-15"
+      />
+    )
+
+    // Act
+    fireEvent.press(getByTestId('calendar-next-month'))
+
+    // Assert
+    expect(queryByTestId('calendar-selected-day-recap')).toBeNull()
+  })
+})

--- a/src/components/__tests__/Statistics.causality.test.tsx
+++ b/src/components/__tests__/Statistics.causality.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render } from '@testing-library/react-native'
-import { Statistics } from '../Statistics'
 import { Category, StatsData } from '@/src/types'
+import { Statistics } from '../Statistics'
 
 const categories: Category[] = [
   { id: 'business', name: 'Business' },

--- a/src/components/__tests__/Statistics.causality.test.tsx
+++ b/src/components/__tests__/Statistics.causality.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { Statistics } from '../Statistics'
+import { Category, StatsData } from '@/src/types'
+
+const categories: Category[] = [
+  { id: 'business', name: 'Business' },
+  { id: 'life', name: 'Life' },
+]
+
+const emptyStats: StatsData = {
+  activeDays: 0,
+  categoryBreakdown: {},
+  completionRate: 0,
+  dailyAverage: 0,
+  journalDays: 0,
+  streakDays: 0,
+  totalTasks: 0,
+}
+
+const activeStats: StatsData = {
+  activeDays: 2,
+  categoryBreakdown: {
+    business: { completed: 3, total: 4 },
+  },
+  completionRate: 0.5,
+  dailyAverage: 1.5,
+  journalDays: 1,
+  streakDays: 2,
+  totalTasks: 3,
+}
+
+describe('Statistics completion causality', () => {
+  it('explains the next action when the selected period has no completions', () => {
+    // Arrange
+    const { getByTestId, getByText } = render(
+      <Statistics
+        categories={categories}
+        monthlyStats={emptyStats}
+        weeklyStats={emptyStats}
+      />
+    )
+
+    // Assert
+    expect(getByTestId('stats-period-recap')).toBeTruthy()
+    expect(getByText('stats.periodEmptyNextAction')).toBeTruthy()
+  })
+
+  it('recaps the completed tasks that feed Calendar and Stats', () => {
+    // Arrange
+    const { getByTestId, getByText } = render(
+      <Statistics
+        categories={categories}
+        monthlyStats={activeStats}
+        weeklyStats={activeStats}
+      />
+    )
+
+    // Assert
+    expect(getByTestId('stats-period-recap')).toBeTruthy()
+    expect(getByText('stats.periodRecap')).toBeTruthy()
+  })
+})

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -34,6 +34,11 @@ const en = {
     monthlySummaryCompleted: '{{count}} completed',
     monthlySummaryActiveDays: '{{count}} active days',
     monthlySummaryEmpty: 'No completions yet',
+    monthlySummaryEmptyHint:
+      'Complete a habit from Today to start filling this calendar.',
+    monthlySummaryHint:
+      'This updates automatically as you finish habits from Today.',
+    selectedDateCompleted: '{{count}} completed on the selected day',
     thisMonth: 'This Month',
     thisWeek: 'This Week',
     dateA11y: '{{day}}',
@@ -128,6 +133,10 @@ const en = {
     streakEncourageGreat: 'Amazing consistency!',
     streakEncourageAmazing: 'Incredible dedication!',
     periodStats: '{{period}} Stats',
+    periodRecap:
+      '{{count}} completed tasks across {{days}} active days. Calendar and Stats update from Today completions.',
+    periodEmptyNextAction:
+      'Complete one Today task to start filling Calendar and Stats.',
     totalTasks: 'Total Tasks',
     dailyAverage: 'Daily Average',
     dailyAverageValue: '{{value}}',
@@ -136,6 +145,7 @@ const en = {
     journalDaysValue: '{{count}} days',
     journalDaysSubtitle: '{{percentage}} of total',
     categoryBreakdown: 'Category Breakdown',
+    unknownCategory: 'Unknown category',
     categoryNoData: 'No data yet',
     categoryNoDataHint: 'Complete tasks to see statistics',
     categoryCompletionRate: 'Rate: {{rate}}',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -34,6 +34,11 @@ const ja = {
     monthlySummaryCompleted: '{{count}}件完了',
     monthlySummaryActiveDays: '{{count}}日活動',
     monthlySummaryEmpty: 'まだ完了タスクがありません',
+    monthlySummaryEmptyHint:
+      'Todayで習慣を完了すると、このカレンダーに反映されます。',
+    monthlySummaryHint:
+      'Todayで習慣を完了するたびに自動で更新されます。',
+    selectedDateCompleted: '選択した日は{{count}}件完了しています',
     thisMonth: '今月',
     thisWeek: '今週',
     dateA11y: '{{day}}日',
@@ -127,6 +132,10 @@ const ja = {
     streakEncourageGreat: '素晴らしい継続力です！',
     streakEncourageAmazing: '驚異的な継続力です！',
     periodStats: '{{period}}の統計',
+    periodRecap:
+      '{{days}}日間で{{count}}件完了しています。Todayの完了がカレンダーと統計に反映されます。',
+    periodEmptyNextAction:
+      'Todayで1つ完了すると、カレンダーと統計が動き始めます。',
     totalTasks: '総タスク数',
     dailyAverage: '1日平均',
     dailyAverageValue: '{{value}}個',
@@ -135,6 +144,7 @@ const ja = {
     journalDaysValue: '{{count}}日',
     journalDaysSubtitle: '全体の{{percentage}}',
     categoryBreakdown: 'カテゴリー別実績',
+    unknownCategory: '不明なカテゴリー',
     categoryNoData: 'まだデータがありません',
     categoryNoDataHint: 'タスクを完了すると統計が表示されます',
     categoryCompletionRate: '完了率: {{rate}}',


### PR DESCRIPTION
## Summary
- add Calendar empty/completed guidance so Today completions visibly explain their effect
- add Stats period recap/empty next-action copy
- add focused causality tests for Calendar and Statistics

## Validation
- pnpm typecheck
- pnpm lint
- pnpm exec jest --runInBand src/components/__tests__/Calendar.causality.test.tsx src/components/__tests__/Statistics.causality.test.tsx
- pnpm exec jest --runInBand
- pnpm test:e2e:production:single maestro/ios/06-calendar-browsing.yaml
- pnpm test:e2e:production:single maestro/ios/08-statistics.yaml
- git diff --check --cached

## TODO
- Addresses P1-D: Completion-to-stats causality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Period recap card in Statistics showing task count and active days; selected-date recap in Calendar now only shows when the date is visible and has completions
  * Category names fully localized with a fallback for unknown categories

* **Localization**
  * Added new English and Japanese copy for calendar and stats UI (monthly hints, selected-date completed, period recap/empty messages)

* **Tests**
  * Added UI tests covering Calendar and Statistics recap behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/Engage/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->