### PR TITLE
feat: expose interaction accessibility states

### DIFF
--- a/maestro/README.md
+++ b/maestro/README.md
@@ -60,3 +60,14 @@ maestro test maestro/ios/ --include-tags manual
 - Tab buttons use accessibility labels such as `today-tab`, `stats-tab`, and `calendar-tab`.
 - Use `extendedWaitUntil` before assertions because app initialization and SQLite loading are async.
 - Production build is required because DevTools can interfere with E2E stability.
+
+## Known Benign Simulator Logs
+
+These messages can appear during Maestro/XCTest runs without indicating an app-originated interaction bug:
+
+- `XCTAutomationSupportErrorUnknownElement: Error getting main window Unknown kAXError value -25218`
+- `XCTAutomationSupport Automation type mismatch`
+- `RCTScrollViewComponentView implements focusItemsInRect`
+- `NSBundle (null) initWithPath failed because the resolved path is empty or nil`
+
+Treat them as platform or test-runner noise unless they accompany a failed assertion, a stuck flow, or a reproducible app UI regression.

--- a/src/components/AppPressable.tsx
+++ b/src/components/AppPressable.tsx
@@ -92,9 +92,9 @@ export const AppPressable = React.forwardRef<
       ref={ref}
       accessibilityState={{
         ...accessibilityState,
-        busy: busy || accessibilityState?.busy,
+        busy: busy || Boolean(accessibilityState?.busy),
         checked: checked ?? accessibilityState?.checked,
-        disabled: isUnavailable || accessibilityState?.disabled,
+        disabled: isUnavailable || Boolean(accessibilityState?.disabled),
         selected: selected ?? accessibilityState?.selected,
       }}
       className={[

--- a/src/components/BackupManager.tsx
+++ b/src/components/BackupManager.tsx
@@ -343,6 +343,10 @@ export const BackupManager: React.FC = () => {
           <Button
             onPress={handleCreateBackup}
             disabled={isLoading}
+            accessibilityState={{
+              busy: isLoading,
+              disabled: isLoading,
+            }}
             className="w-full"
             testID="backup-create-button"
           >
@@ -354,6 +358,10 @@ export const BackupManager: React.FC = () => {
           <Button
             onPress={handleExportData}
             disabled={isLoading}
+            accessibilityState={{
+              busy: isLoading,
+              disabled: isLoading,
+            }}
             variant="outline"
             className="w-full"
             testID="backup-export-button"
@@ -366,6 +374,10 @@ export const BackupManager: React.FC = () => {
           <Button
             onPress={handleImportBackup}
             disabled={isLoading}
+            accessibilityState={{
+              busy: isLoading,
+              disabled: isLoading,
+            }}
             variant="outline"
             className="w-full"
             testID="backup-import-button"
@@ -447,6 +459,10 @@ export const BackupManager: React.FC = () => {
                 <Button
                   onPress={() => handleDeleteBackup(backup.fileName)}
                   disabled={isLoading}
+                  accessibilityState={{
+                    busy: isLoading,
+                    disabled: isLoading,
+                  }}
                   variant="outline"
                   size="sm"
                   className="self-start"

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -196,6 +196,29 @@ export const Calendar: React.FC<CalendarProps> = ({
     return t('calendar.dateA11y', { day })
   }
 
+  /**
+   * Describes calendar state that React Native does not expose as accessibilityState.
+   * @param isCurrentMonth - Whether the cell belongs to the visible calendar month.
+   * @param isCurrentDate - Whether the cell represents today.
+   * @returns A localized value string for VoiceOver, or `undefined` when no extra state is needed.
+   * @example
+   * getDateA11yValue(false, false) // => 'Outside this month'
+   */
+  const getDateA11yValue = (
+    isCurrentMonth: boolean,
+    isCurrentDate: boolean
+  ): string | undefined => {
+    if (isCurrentDate) {
+      return t('calendar.currentDateA11yValue')
+    }
+
+    if (!isCurrentMonth) {
+      return t('calendar.outsideMonthA11yValue')
+    }
+
+    return undefined
+  }
+
   return (
     <Box className="flex-1 bg-gray-50" testID="calendar-component">
       {/* Header with month navigation - matching Figma design */}
@@ -258,11 +281,19 @@ export const Calendar: React.FC<CalendarProps> = ({
             {week.map((dayData, dayIndex) => {
               const completionCount = achievementData[dayData.dateString] || 0
               const heatmapColor = getHeatmapColor(completionCount)
-              const isSelectedDate = isSelected(dayData.dateString)
+              const isCurrentDate = isToday(dayData.dateString)
+              const isInteractiveDate = dayData.isCurrentMonth
+              const isSelectedDate =
+                isInteractiveDate && isSelected(dayData.dateString)
+              const dateAccessibilityValue = getDateA11yValue(
+                isInteractiveDate,
+                isCurrentDate
+              )
 
               return (
                 <AppPressable
                   key={`${weekIndex}-${dayIndex}`}
+                  disabled={!isInteractiveDate}
                   feedback="select"
                   onPress={() => onDateSelect(dayData.dateString)}
                   testID={`calendar-date-${dayData.dateString}`}
@@ -270,6 +301,11 @@ export const Calendar: React.FC<CalendarProps> = ({
                   pressedClassName="opacity-80"
                   selected={isSelectedDate}
                   accessibilityLabel={getDateA11yLabel(dayData.date, dayData.dateString, completionCount)}
+                  accessibilityValue={
+                    dateAccessibilityValue
+                      ? { text: dateAccessibilityValue }
+                      : undefined
+                  }
                   accessibilityRole="button"
                 >
                   <Box
@@ -287,7 +323,7 @@ export const Calendar: React.FC<CalendarProps> = ({
                           : ''
                       }
                       ${
-                        isToday(dayData.dateString)
+                        isCurrentDate
                           ? 'border-2 border-orange-500'
                           : ''
                       }
@@ -302,7 +338,7 @@ export const Calendar: React.FC<CalendarProps> = ({
                             : 'text-gray-300'
                         }
                         ${isSelectedDate ? 'text-blue-600' : ''}
-                        ${isToday(dayData.dateString) ? 'text-orange-600' : ''}
+                        ${isCurrentDate ? 'text-orange-600' : ''}
                       `}
                     >
                       {dayData.date}

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -201,6 +201,40 @@ export function NotificationSettings({ onClose }: NotificationSettingsProps) {
     }
   }
 
+  /**
+   * Opens OS notification settings while exposing a pending state to assistive tech.
+   * @returns A promise that settles after the platform settings request finishes.
+   * @example
+   * await handleOpenNotificationSettings()
+   */
+  const handleOpenNotificationSettings = async (): Promise<void> => {
+    setIsSaving(true)
+    setOperationMessage(null)
+
+    try {
+      await openNotificationSettings()
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  /**
+   * Refreshes permission state while keeping the pressed action busy and disabled.
+   * @returns A promise that settles after notification settings are reloaded.
+   * @example
+   * await handleRefreshSettings()
+   */
+  const handleRefreshSettings = async (): Promise<void> => {
+    setIsSaving(true)
+    setOperationMessage(null)
+
+    try {
+      await refreshSettings()
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
   if (isLoading) {
     return (
       <View className="flex-1 justify-center items-center p-6">
@@ -227,6 +261,10 @@ export function NotificationSettings({ onClose }: NotificationSettingsProps) {
               onValueChange={handleReminderToggle}
               disabled={isDenied || isSaving}
               testID="notification-reminder-switch"
+              accessibilityState={{
+                busy: isSaving,
+                disabled: isDenied || isSaving,
+              }}
               trackColor={{ false: '#E5E7EB', true: '#007AFF' }}
               thumbColor={settings.enabled ? '#FFFFFF' : '#9CA3AF'}
               accessibilityHint={
@@ -291,6 +329,7 @@ export function NotificationSettings({ onClose }: NotificationSettingsProps) {
                     key={`${time.hour}-${time.minute}`}
                     onPress={() => handleTimeChange(time.hour, time.minute)}
                     selected={isSelected}
+                    busy={isSaving}
                     disabled={isSaving}
                     feedback="select"
                     className={`
@@ -355,7 +394,8 @@ export function NotificationSettings({ onClose }: NotificationSettingsProps) {
         <VStack className="gap-3">
           {isDenied && (
             <AppPressable
-              onPress={openNotificationSettings}
+              onPress={handleOpenNotificationSettings}
+              busy={isSaving}
               disabled={isSaving}
               feedback="select"
               className="w-full bg-system-blue rounded-lg py-3 touch-target-minimum"
@@ -370,7 +410,8 @@ export function NotificationSettings({ onClose }: NotificationSettingsProps) {
           )}
 
           <AppPressable
-            onPress={refreshSettings}
+            onPress={handleRefreshSettings}
+            busy={isSaving}
             disabled={isSaving}
             feedback="select"
             className="w-full bg-secondary-system-background rounded-lg py-3 touch-target-minimum"
@@ -386,6 +427,7 @@ export function NotificationSettings({ onClose }: NotificationSettingsProps) {
           {onClose && (
             <AppPressable
               onPress={onClose}
+              busy={isSaving}
               disabled={isSaving}
               feedback="select"
               className="w-full bg-system-blue rounded-lg py-3 touch-target-minimum"

--- a/src/components/PresetTaskEditor.tsx
+++ b/src/components/PresetTaskEditor.tsx
@@ -643,6 +643,10 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
                 isSaveDisabled ? 'bg-gray-400' : 'bg-blue-500'
               }`}
               testID="preset-editor-save"
+              accessibilityState={{
+                busy: isLoading,
+                disabled: isSaveDisabled,
+              }}
               accessibilityHint={
                 saveDisabledReason ? t(saveDisabledReason) : undefined
               }

--- a/src/components/__tests__/BackupManager.test.tsx
+++ b/src/components/__tests__/BackupManager.test.tsx
@@ -62,4 +62,39 @@ describe('BackupManager', () => {
     expect(getByTestId('backup-operation-feedback')).toBeTruthy()
     expect(Alert.alert).not.toHaveBeenCalled()
   })
+
+  it('exposes busy and disabled state while a backup is being created', async () => {
+    // Arrange
+    let resolveBackup: (result: {
+      success: boolean
+      fileName: string
+      size: number
+      errors: string[]
+    }) => void = () => {}
+    store.createBackup.mockReturnValue(
+      new Promise((resolve) => {
+        resolveBackup = resolve
+      })
+    )
+    const { getByTestId } = render(<BackupManager />)
+
+    // Act
+    fireEvent.press(getByTestId('backup-create-button'))
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        getByTestId('backup-create-button').props.accessibilityState
+      ).toMatchObject({
+        busy: true,
+        disabled: true,
+      })
+    })
+    resolveBackup({
+      success: true,
+      fileName: 'engage-backup.json',
+      size: 2048,
+      errors: [],
+    })
+  })
 })

--- a/src/components/__tests__/Calendar.causality.test.tsx
+++ b/src/components/__tests__/Calendar.causality.test.tsx
@@ -3,6 +3,10 @@ import { fireEvent, render } from '@testing-library/react-native'
 import { Calendar } from '../Calendar'
 
 describe('Calendar completion causality', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   it('guides users to complete a Today habit when the month has no completions', () => {
     // Arrange
     const { getByTestId, getByText, queryByTestId } = render(
@@ -49,5 +53,46 @@ describe('Calendar completion causality', () => {
 
     // Assert
     expect(queryByTestId('calendar-selected-day-recap')).toBeNull()
+  })
+
+  it('exposes selected, current, and disabled states on calendar cells', () => {
+    // Arrange
+    jest.useFakeTimers().setSystemTime(new Date(2026, 4, 15, 12))
+    const onDateSelect = jest.fn()
+    const { getByTestId } = render(
+      <Calendar
+        achievementData={{}}
+        onDateSelect={onDateSelect}
+        selectedDate="2026-05-15"
+      />
+    )
+
+    // Act
+    fireEvent.press(getByTestId('calendar-date-2026-04-26'))
+
+    // Assert
+    expect(
+      getByTestId('calendar-date-2026-05-15').props.accessibilityState
+    ).toMatchObject({
+      disabled: false,
+      selected: true,
+    })
+    expect(
+      getByTestId('calendar-date-2026-05-15').props.accessibilityValue
+    ).toMatchObject({
+      text: 'calendar.currentDateA11yValue',
+    })
+    expect(
+      getByTestId('calendar-date-2026-04-26').props.accessibilityState
+    ).toMatchObject({
+      disabled: true,
+      selected: false,
+    })
+    expect(
+      getByTestId('calendar-date-2026-04-26').props.accessibilityValue
+    ).toMatchObject({
+      text: 'calendar.outsideMonthA11yValue',
+    })
+    expect(onDateSelect).not.toHaveBeenCalled()
   })
 })

--- a/src/components/__tests__/NotificationSettings.test.tsx
+++ b/src/components/__tests__/NotificationSettings.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react-native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import { NotificationSettings } from '../NotificationSettings'
 
 const mockOpenNotificationSettings = jest.fn()
@@ -179,5 +179,36 @@ describe('NotificationSettings', () => {
     expect(getByText('Your daily reminder is scheduled for 20:00.')).toBeTruthy()
     expect(getByText('Current time: 20:00')).toBeTruthy()
     expect(getByTestId('notification-state-scheduled')).toBeTruthy()
+  })
+
+  it('exposes busy and disabled state while checking permissions', async () => {
+    // Arrange
+    let resolveRefresh: () => void = () => {}
+    mockRefreshSettings.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRefresh = resolve
+      })
+    )
+    const { getByTestId } = render(<NotificationSettings />)
+
+    // Act
+    fireEvent.press(getByTestId('notification-check-permission'))
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        getByTestId('notification-check-permission').props.accessibilityState
+      ).toMatchObject({
+        busy: true,
+        disabled: true,
+      })
+    })
+    expect(
+      getByTestId('notification-reminder-switch').props.accessibilityState
+    ).toMatchObject({
+      busy: true,
+      disabled: true,
+    })
+    resolveRefresh()
   })
 })

--- a/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
+++ b/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react-native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import { Alert } from 'react-native'
 import { Category, Task } from '@/src/types'
 import { PresetTaskEditor } from '../PresetTaskEditor'
@@ -65,6 +65,9 @@ describe('PresetTaskEditor form safety', () => {
       0
     )
     expect(getByTestId('preset-editor-save').props.disabled).toBe(true)
+    expect(getByTestId('preset-editor-save').props.accessibilityState).toMatchObject({
+      disabled: true,
+    })
     expect(onSave).not.toHaveBeenCalled()
   })
 
@@ -116,5 +119,31 @@ describe('PresetTaskEditor form safety', () => {
       'presetEditor.deleteTaskConfirm',
       expect.any(Array)
     )
+  })
+
+  it('exposes busy and disabled state while saving preset tasks', async () => {
+    // Arrange
+    let resolveSave: () => void = () => {}
+    const onSave = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve
+        })
+    )
+    const { getByTestId } = renderEditor({ onSave })
+
+    // Act
+    fireEvent.press(getByTestId('preset-editor-save'))
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        getByTestId('preset-editor-save').props.accessibilityState
+      ).toMatchObject({
+        busy: true,
+        disabled: true,
+      })
+    })
+    resolveSave()
   })
 })

--- a/src/components/__tests__/Statistics.causality.test.tsx
+++ b/src/components/__tests__/Statistics.causality.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react-native'
+import { fireEvent, render } from '@testing-library/react-native'
 import { Category, StatsData } from '@/src/types'
 import { Statistics } from '../Statistics'
 
@@ -59,5 +59,27 @@ describe('Statistics completion causality', () => {
     // Assert
     expect(getByTestId('stats-period-recap')).toBeTruthy()
     expect(getByText('stats.periodRecap')).toBeTruthy()
+  })
+
+  it('exposes selected state as the segmented period changes', () => {
+    // Arrange
+    const { getByTestId } = render(
+      <Statistics
+        categories={categories}
+        monthlyStats={activeStats}
+        weeklyStats={activeStats}
+      />
+    )
+
+    // Act
+    fireEvent.press(getByTestId('stats-month-toggle'))
+
+    // Assert
+    expect(getByTestId('stats-week-toggle').props.accessibilityState).toMatchObject({
+      selected: false,
+    })
+    expect(getByTestId('stats-month-toggle').props.accessibilityState).toMatchObject({
+      selected: true,
+    })
   })
 })

--- a/src/components/__tests__/TaskPicker.test.tsx
+++ b/src/components/__tests__/TaskPicker.test.tsx
@@ -213,7 +213,7 @@ describe('TaskPicker', () => {
     expect(getByText('presetEditor.addTask')).toBeTruthy()
   })
 
-  it('prevents duplicate assignment saves while confirm is already pending', () => {
+  it('prevents duplicate assignment saves while confirm is already pending', async () => {
     // Arrange
     let resolveSave: (result: TaskAssignmentOperationResult) => void = () => {}
     mockOnTaskSelect.mockReturnValue(
@@ -226,9 +226,17 @@ describe('TaskPicker', () => {
     // Act
     fireEvent.press(getByTestId('task-picker-confirm'))
     fireEvent.press(getByTestId('task-picker-confirm'))
-    resolveSave(successResult)
 
     // Assert
+    await waitFor(() => {
+      expect(
+        getByTestId('task-picker-confirm').props.accessibilityState
+      ).toMatchObject({
+        busy: true,
+        disabled: true,
+      })
+    })
     expect(mockOnTaskSelect).toHaveBeenCalledTimes(1)
+    resolveSave(successResult)
   })
 })

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -45,6 +45,8 @@ const en = {
     dateA11yToday: '{{day}}, today',
     dateA11yCompleted: '{{day}}, {{count}} completed',
     dateA11yTodayCompleted: '{{day}}, today, {{count}} completed',
+    currentDateA11yValue: 'Current day',
+    outsideMonthA11yValue: 'Outside this month',
   },
 
   daySheet: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -45,6 +45,8 @@ const ja = {
     dateA11yToday: '{{day}}日 今日',
     dateA11yCompleted: '{{day}}日 {{count}}件完了',
     dateA11yTodayCompleted: '{{day}}日 今日 {{count}}件完了',
+    currentDateA11yValue: '今日',
+    outsideMonthA11yValue: '表示中の月ではありません',
   },
 
   daySheet: {


### PR DESCRIPTION
## Summary
- expose explicit accessibility selected/current/disabled state for calendar cells and segmented controls
- add busy/disabled accessibility state to async action controls across TaskPicker, notifications, preset tasks, and backups
- document known benign Maestro/XCTest simulator logs for QA triage

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check
- kill-port 8081 && pnpm build:e2e
- pnpm test:e2e:production:single maestro/ios/02-tab-navigation.yaml maestro/ios/04-task-completion.yaml maestro/ios/06-calendar-browsing.yaml maestro/ios/07-edit-presets.yaml maestro/ios/08-statistics.yaml maestro/ios/09-settings.yaml maestro/ios/11-backup-create.yaml

## Notes
- gstack-review: clean, 0 findings
- pnpm exec expo install --check reports existing Expo SDK patch drift on main; no package changes were made in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guidance on known simulator log messages that may appear during iOS E2E testing.

* **New Features**
  * Enhanced accessibility support across app components to better reflect busy and disabled states during operations.
  * Added localized accessibility descriptions for calendar dates.

* **Tests**
  * Added test coverage validating accessibility state behavior during user interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/Engage/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->