### PR TITLE
docs: document simulator runtime noise

### DIFF
--- a/maestro/README.md
+++ b/maestro/README.md
@@ -68,6 +68,9 @@ These messages can appear during Maestro/XCTest runs without indicating an app-o
 - `XCTAutomationSupportErrorUnknownElement: Error getting main window Unknown kAXError value -25218`
 - `XCTAutomationSupport Automation type mismatch`
 - `RCTScrollViewComponentView implements focusItemsInRect`
+- `UIKeyboardLayoutStar implements focusItemsInRect`
 - `NSBundle (null) initWithPath failed because the resolved path is empty or nil`
+- `TextInputUI Received external candidate resultset`
+- `CoreHaptics ... hapticpatternlibrary.plist could not be opened`
 
 Treat them as platform or test-runner noise unless they accompany a failed assertion, a stuck flow, or a reproducible app UI regression.


### PR DESCRIPTION
## Summary
- document additional benign simulator logs observed during final Maestro QA

## Validation
- git diff --check
- gstack-review: clean, docs-only
- final QA before this follow-up: pnpm test:e2e:production 7/7 and manual flows 3/3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the known benign simulator logs section to expand the list of acceptable noise. Additions include entries related to keyboard layout focus, empty or nil initialization paths, external candidate resultsets, and CoreHaptics plist open failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/Engage/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->