### PR TITLE
fix: stabilize preset task editing flow

### DIFF
--- a/maestro/README.md
+++ b/maestro/README.md
@@ -31,7 +31,7 @@ pnpm test:e2e:production:single maestro/ios/06-calendar-browsing.yaml
 - `04-task-completion.yaml`: task assignment + completion
 - `05-journal-entry.yaml`: journal input + autosave
 - `06-calendar-browsing.yaml`: calendar navigation + DayModal date regression
-- `07-edit-presets.yaml`: TaskPicker to PresetTaskEditor modal flow
+- `07-edit-presets.yaml`: TaskPicker to PresetTaskEditor modal flow + keyboard/category stability regression
 - `10-data-persistence.yaml`: SQLite state survives restart
 - `11-backup-create.yaml`: backup creation regression
 

--- a/maestro/ios/07-edit-presets.yaml
+++ b/maestro/ios/07-edit-presets.yaml
@@ -45,6 +45,32 @@ tags:
 - assertVisible:
     id: "preset-editor-close"
 
+# Regression: Adding a task should focus the new row without showing the
+# preset Save footer above the keyboard.
+- tapOn:
+    id: "add-task-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "preset-editor-inline-keyboard-done-button"
+    timeout: 5000
+
+- inputText: "E2EStableTask"
+
+- assertVisible:
+    text: "E2EStableTask"
+
+- assertNotVisible:
+    id: "preset-editor-save"
+
+# Regression: Changing category while editing should not move the active row
+# out of the visible keyboard-safe area.
+- tapOn:
+    id: "latest-new-task-category-option-life"
+
+- assertVisible:
+    text: "E2EStableTask"
+
 # Close PresetTaskEditor
 - tapOn:
     id: "preset-editor-close"

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -66,6 +66,7 @@ jest.mock('react-native', () => {
       flatten: jest.fn((style) => style),
     },
     Keyboard: {
+      addListener: jest.fn(() => ({ remove: jest.fn() })),
       dismiss: jest.fn(),
     },
     Dimensions: {

--- a/src/components/PresetTaskEditor.tsx
+++ b/src/components/PresetTaskEditor.tsx
@@ -182,8 +182,13 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
     () => validatePresetTaskDrafts(editingTasks),
     [editingTasks]
   )
+  const indexedEditingTasks = useMemo(
+    () => editingTasks.map((task, index) => ({ ...task, index })),
+    [editingTasks]
+  )
   const saveDisabledReason = taskValidation.formMessages[0] ?? null
   const isSaveDisabled = isLoading || !taskValidation.isValid
+  const shouldShowPresetEditorActions = !isPresetKeyboardDoneVisible
 
   // Initialize editing tasks when modal opens
   useEffect(() => {
@@ -206,7 +211,27 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
     }
   }, [isVisible, tasks])
 
-  // Get category color (lookup by category ID)
+  useEffect(() => {
+    const keyboardDidHideSubscription = Keyboard.addListener(
+      'keyboardDidHide',
+      () => {
+        // Native keyboard dismissal should restore the footer actions too.
+        setIsPresetKeyboardDoneVisible(false)
+      }
+    )
+
+    return () => {
+      keyboardDidHideSubscription.remove()
+    }
+  }, [])
+
+  /**
+   * Resolves a chip color for preset categories when the editor renders task rows.
+   * @param categoryId - The category ID assigned to the editable task.
+   * @returns A NativeWind background class for the category dot.
+   * @example
+   * getCategoryColor('business') // => 'bg-blue-500'
+   */
   const getCategoryColor = (categoryId: string) => {
     // Default colors for preset categories
     if (categoryId === 'business') return 'bg-blue-500'
@@ -224,6 +249,12 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
     return colors[index]
   }
 
+  /**
+   * Appends a blank preset row when the Add Task button is pressed.
+   * @returns Nothing; queues focus so users can type the new title immediately.
+   * @example
+   * addNewTask() // adds a blank row and focuses its title input
+   */
   const addNewTask = () => {
     const newTask: EditingTask = {
       title: '',
@@ -262,6 +293,16 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
    */
   const handlePresetInputFocus = (): void => {
     setIsPresetKeyboardDoneVisible(true)
+  }
+
+  /**
+   * Restores the preset footer after native text inputs lose focus.
+   * @returns Nothing; hides the temporary keyboard Done action.
+   * @example
+   * handlePresetInputBlur() // restores Save and Cancel after editing ends
+   */
+  const handlePresetInputBlur = (): void => {
+    setIsPresetKeyboardDoneVisible(false)
   }
 
   /**
@@ -304,6 +345,14 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
     focusPendingTaskTitleInput(taskIndex, event.nativeEvent.layout.y)
   }
 
+  /**
+   * Applies a small draft update from text fields or category chips.
+   * @param index - The editing-task index to update.
+   * @param updates - The partial task draft fields changed by the control.
+   * @returns Nothing; updates local draft state and clears stale feedback.
+   * @example
+   * updateTask(0, { categoryId: 'life' }) // changes row 0 to Life
+   */
   const updateTask = (index: number, updates: Partial<EditingTask>) => {
     setOperationFeedback(null)
     setEditingTasks((prev) =>
@@ -419,15 +468,6 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
     )
   }
 
-  // Group tasks by category for display
-  const tasksByCategory = editingTasks.reduce((acc, task, index) => {
-    if (!acc[task.categoryId]) {
-      acc[task.categoryId] = []
-    }
-    acc[task.categoryId].push({ ...task, index })
-    return acc
-  }, {} as Record<string, (EditingTask & { index: number })[]>)
-
   return (
     <Modal
       visible={isVisible}
@@ -493,216 +533,179 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
           keyboardShouldPersistTaps="handled"
         >
           <VStack space="lg">
-            {Object.entries(tasksByCategory).map(
-              ([categoryId, categoryTasks]) => {
-                const category = categories.find((c) => c.id === categoryId)
-                const categoryColor = getCategoryColor(categoryId)
+            {indexedEditingTasks.map((task) => {
+              const validationMessages =
+                taskValidation.taskMessages[task.index] ?? []
+              const hasValidationError = validationMessages.length > 0
+              const isLatestNewTask =
+                task.isNew === true &&
+                task.index === indexedEditingTasks.length - 1
 
-                return (
-                  <VStack key={categoryId} space="sm">
-                    {/* Category Header */}
-                    <HStack className="items-center justify-between">
-                      <HStack className="items-center" space="sm">
-                        <Box
-                          className={`w-4 h-4 rounded-full ${categoryColor}`}
-                        />
-                        <Text className="text-lg font-semibold text-gray-800">
-                          {category
-                            ? getCategoryDisplayName(category)
-                            : t('presetEditor.unknownCategory')}
+              return (
+                <Box
+                  key={task.index}
+                  className="p-4 bg-gray-50 rounded-lg border border-gray-200"
+                  onLayout={(event) => handleTaskCardLayout(task.index, event)}
+                >
+                  <VStack space="md">
+                    {/* Task Title */}
+                    <VStack space="xs">
+                      <Text className="text-sm font-medium text-gray-700">
+                        {t('presetEditor.taskName')}
+                      </Text>
+                      <TextInput
+                        ref={(input) => {
+                          taskTitleInputRefs.current[task.index] = input
+                        }}
+                        value={task.title}
+                        onChangeText={(text) =>
+                          updateTask(task.index, { title: text })
+                        }
+                        autoFocus={task.index === pendingFocusedTaskIndex}
+                        inputAccessoryViewID={inputAccessoryViewID}
+                        onFocus={handlePresetInputFocus}
+                        onBlur={handlePresetInputBlur}
+                        onSubmitEditing={handleKeyboardDone}
+                        placeholder={t('presetEditor.taskNamePlaceholder')}
+                        returnKeyType="done"
+                        submitBehavior="blurAndSubmit"
+                        className={`bg-white border rounded-lg px-3 py-2 text-gray-800 ${
+                          hasValidationError
+                            ? 'border-red-300'
+                            : 'border-gray-300'
+                        }`}
+                        testID={`task-title-input-${task.index}`}
+                        accessibilityHint={
+                          hasValidationError
+                            ? validationMessages
+                                .map((messageKey) => t(messageKey))
+                                .join(' ')
+                            : undefined
+                        }
+                      />
+                      {validationMessages.map((messageKey) => (
+                        <Text
+                          key={`${task.index}-${messageKey}`}
+                          className="text-xs font-medium text-red-600"
+                          testID={`task-title-error-${task.index}`}
+                        >
+                          {t(messageKey)}
                         </Text>
-                      </HStack>
-                    </HStack>
-
-                    {/* Tasks in Category */}
-                    <VStack space="sm">
-                      {categoryTasks.map((task) => {
-                        const validationMessages =
-                          taskValidation.taskMessages[task.index] ?? []
-                        const hasValidationError =
-                          validationMessages.length > 0
-
-                        return (
-                          <Box
-                            key={task.index}
-                            className="p-4 bg-gray-50 rounded-lg border border-gray-200"
-                            onLayout={(event) =>
-                              handleTaskCardLayout(task.index, event)
-                            }
-                          >
-                            <VStack space="md">
-                              {/* Task Title */}
-                              <VStack space="xs">
-                                <Text className="text-sm font-medium text-gray-700">
-                                  {t('presetEditor.taskName')}
-                                </Text>
-                                <TextInput
-                                  ref={(input) => {
-                                    taskTitleInputRefs.current[task.index] =
-                                      input
-                                  }}
-                                  value={task.title}
-                                  onChangeText={(text) =>
-                                    updateTask(task.index, { title: text })
-                                  }
-                                  autoFocus={
-                                    task.index === pendingFocusedTaskIndex
-                                  }
-                                  inputAccessoryViewID={inputAccessoryViewID}
-                                  onFocus={handlePresetInputFocus}
-                                  onSubmitEditing={handleKeyboardDone}
-                                  placeholder={t(
-                                    'presetEditor.taskNamePlaceholder'
-                                  )}
-                                  returnKeyType="done"
-                                  submitBehavior="blurAndSubmit"
-                                  className={`bg-white border rounded-lg px-3 py-2 text-gray-800 ${
-                                    hasValidationError
-                                      ? 'border-red-300'
-                                      : 'border-gray-300'
-                                  }`}
-                                  testID={`task-title-input-${task.index}`}
-                                  accessibilityHint={
-                                    hasValidationError
-                                      ? validationMessages
-                                          .map((messageKey) => t(messageKey))
-                                          .join(' ')
-                                      : undefined
-                                  }
-                                />
-                                {validationMessages.map((messageKey) => (
-                                  <Text
-                                    key={`${task.index}-${messageKey}`}
-                                    className="text-xs font-medium text-red-600"
-                                    testID={`task-title-error-${task.index}`}
-                                  >
-                                    {t(messageKey)}
-                                  </Text>
-                                ))}
-                              </VStack>
-
-                              {/* Category Selection */}
-                              <VStack space="xs">
-                                <Text className="text-sm font-medium text-gray-700">
-                                  {t('presetEditor.category')}
-                                </Text>
-                                <ScrollView
-                                  horizontal
-                                  showsHorizontalScrollIndicator={false}
-                                >
-                                  <HStack space="sm">
-                                    {categories.map((cat) => {
-                                      const isSelected =
-                                        task.categoryId === cat.id
-                                      const catColor = getCategoryColor(cat.id)
-
-                                      return (
-                                        <Pressable
-                                          key={cat.id}
-                                          onPress={() =>
-                                            updateTask(task.index, {
-                                              categoryId: cat.id,
-                                            })
-                                          }
-                                          className={`
-                                          px-3 py-2 rounded-full border-2 flex-row items-center
-                                          ${
-                                            isSelected
-                                              ? 'border-blue-500 bg-blue-50'
-                                              : 'border-gray-300 bg-white'
-                                          }
-                                        `}
-                                          testID={`category-option-${cat.id}-${task.index}`}
-                                          accessibilityLabel={getCategoryDisplayName(
-                                            cat
-                                          )}
-                                          accessibilityRole="button"
-                                          accessibilityState={{
-                                            selected: isSelected,
-                                          }}
-                                        >
-                                          <Box
-                                            className={`w-3 h-3 rounded-full ${catColor} mr-2`}
-                                          />
-                                          <Text
-                                            className={`text-sm ${
-                                              isSelected
-                                                ? 'text-blue-700'
-                                                : 'text-gray-700'
-                                            }`}
-                                          >
-                                            {getCategoryDisplayName(cat)}
-                                          </Text>
-                                        </Pressable>
-                                      )
-                                    })}
-                                  </HStack>
-                                </ScrollView>
-                              </VStack>
-
-                              {/* Default Minutes */}
-                              <VStack space="xs">
-                                <Text className="text-sm font-medium text-gray-700">
-                                  {t('presetEditor.estimatedMinutes')}
-                                </Text>
-                                <TextInput
-                                  ref={(input) => {
-                                    taskMinutesInputRefs.current[task.index] =
-                                      input
-                                  }}
-                                  value={task.defaultMinutes?.toString() || ''}
-                                  onChangeText={(text) => {
-                                    const minutes = text
-                                      ? parseInt(text, 10)
-                                      : undefined
-                                    updateTask(task.index, {
-                                      defaultMinutes: isNaN(minutes!)
-                                        ? undefined
-                                        : minutes,
-                                    })
-                                  }}
-                                  placeholder={t(
-                                    'presetEditor.estimatedMinutesPlaceholder'
-                                  )}
-                                  inputAccessoryViewID={inputAccessoryViewID}
-                                  keyboardType="numeric"
-                                  onFocus={handlePresetInputFocus}
-                                  onSubmitEditing={handleKeyboardDone}
-                                  returnKeyType="done"
-                                  submitBehavior="blurAndSubmit"
-                                  className="bg-white border border-gray-300 rounded-lg px-3 py-2 text-gray-800"
-                                  testID={`task-minutes-input-${task.index}`}
-                                />
-                              </VStack>
-
-                              {/* Actions */}
-                              <HStack className="justify-end">
-                                <Pressable
-                                  onPress={() => deleteTask(task.index)}
-                                  className="bg-red-500 rounded-lg px-4 py-2"
-                                  testID={`delete-task-${task.index}`}
-                                >
-                                  <HStack className="items-center" space="xs">
-                                    <IconSymbol
-                                      name="trash"
-                                      size={16}
-                                      color="white"
-                                    />
-                                    <Text className="text-white text-sm font-medium">
-                                      {t('common.delete')}
-                                    </Text>
-                                  </HStack>
-                                </Pressable>
-                              </HStack>
-                            </VStack>
-                          </Box>
-                        )
-                      })}
+                      ))}
                     </VStack>
+
+                    {/* Category Selection */}
+                    <VStack space="xs">
+                      <Text className="text-sm font-medium text-gray-700">
+                        {t('presetEditor.category')}
+                      </Text>
+                      <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                      >
+                        <HStack space="sm">
+                          {categories.map((cat) => {
+                            const isSelected = task.categoryId === cat.id
+                            const catColor = getCategoryColor(cat.id)
+
+                            return (
+                              <Pressable
+                                key={cat.id}
+                                onPress={() =>
+                                  updateTask(task.index, {
+                                    categoryId: cat.id,
+                                  })
+                                }
+                                className={`
+                                  px-3 py-2 rounded-full border-2 flex-row items-center
+                                  ${
+                                    isSelected
+                                      ? 'border-blue-500 bg-blue-50'
+                                      : 'border-gray-300 bg-white'
+                                  }
+                                `}
+                                testID={
+                                  isLatestNewTask
+                                    ? `latest-new-task-category-option-${cat.id}`
+                                    : `category-option-${cat.id}-${task.index}`
+                                }
+                                accessibilityLabel={getCategoryDisplayName(cat)}
+                                accessibilityRole="button"
+                                accessibilityState={{
+                                  selected: isSelected,
+                                }}
+                              >
+                                <Box
+                                  className={`w-3 h-3 rounded-full ${catColor} mr-2`}
+                                />
+                                <Text
+                                  className={`text-sm ${
+                                    isSelected
+                                      ? 'text-blue-700'
+                                      : 'text-gray-700'
+                                  }`}
+                                >
+                                  {getCategoryDisplayName(cat)}
+                                </Text>
+                              </Pressable>
+                            )
+                          })}
+                        </HStack>
+                      </ScrollView>
+                    </VStack>
+
+                    {/* Default Minutes */}
+                    <VStack space="xs">
+                      <Text className="text-sm font-medium text-gray-700">
+                        {t('presetEditor.estimatedMinutes')}
+                      </Text>
+                      <TextInput
+                        ref={(input) => {
+                          taskMinutesInputRefs.current[task.index] = input
+                        }}
+                        value={task.defaultMinutes?.toString() || ''}
+                        onChangeText={(text) => {
+                          const minutes = text ? parseInt(text, 10) : undefined
+                          updateTask(task.index, {
+                            defaultMinutes: isNaN(minutes!)
+                              ? undefined
+                              : minutes,
+                          })
+                        }}
+                        placeholder={t(
+                          'presetEditor.estimatedMinutesPlaceholder'
+                        )}
+                        inputAccessoryViewID={inputAccessoryViewID}
+                        keyboardType="numeric"
+                        onFocus={handlePresetInputFocus}
+                        onBlur={handlePresetInputBlur}
+                        onSubmitEditing={handleKeyboardDone}
+                        returnKeyType="done"
+                        submitBehavior="blurAndSubmit"
+                        className="bg-white border border-gray-300 rounded-lg px-3 py-2 text-gray-800"
+                        testID={`task-minutes-input-${task.index}`}
+                      />
+                    </VStack>
+
+                    {/* Actions */}
+                    <HStack className="justify-end">
+                      <Pressable
+                        onPress={() => deleteTask(task.index)}
+                        className="bg-red-500 rounded-lg px-4 py-2"
+                        testID={`delete-task-${task.index}`}
+                      >
+                        <HStack className="items-center" space="xs">
+                          <IconSymbol name="trash" size={16} color="white" />
+                          <Text className="text-white text-sm font-medium">
+                            {t('common.delete')}
+                          </Text>
+                        </HStack>
+                      </Pressable>
+                    </HStack>
                   </VStack>
-                )
-              }
-            )}
+                </Box>
+              )
+            })}
 
             {/* New Category Section */}
             <VStack space="sm" className="mb-4">
@@ -733,6 +736,7 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
                     placeholder={t('presetEditor.newCategoryPlaceholder')}
                     inputAccessoryViewID={inputAccessoryViewID}
                     onFocus={handlePresetInputFocus}
+                    onBlur={handlePresetInputBlur}
                     onSubmitEditing={handleKeyboardDone}
                     returnKeyType="done"
                     submitBehavior="blurAndSubmit"
@@ -782,7 +786,7 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
               </Pressable>
             </Box>
           )}
-          {saveDisabledReason && (
+          {shouldShowPresetEditorActions && saveDisabledReason && (
             <Text
               className="mb-3 text-center text-sm font-medium text-red-600"
               testID="preset-editor-save-disabled-reason"
@@ -790,37 +794,39 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
               {t(saveDisabledReason)}
             </Text>
           )}
-          <HStack space="md">
-            <Pressable
-              onPress={handleCancel}
-              className="flex-1 bg-gray-100 rounded-lg py-3"
-              testID="preset-editor-cancel"
-            >
-              <Text className="text-gray-700 font-medium text-center">
-                {t('common.cancel')}
-              </Text>
-            </Pressable>
+          {shouldShowPresetEditorActions && (
+            <HStack space="md">
+              <Pressable
+                onPress={handleCancel}
+                className="flex-1 bg-gray-100 rounded-lg py-3"
+                testID="preset-editor-cancel"
+              >
+                <Text className="text-gray-700 font-medium text-center">
+                  {t('common.cancel')}
+                </Text>
+              </Pressable>
 
-            <Pressable
-              onPress={handleSave}
-              disabled={isSaveDisabled}
-              className={`flex-1 rounded-lg py-3 ${
-                isSaveDisabled ? 'bg-gray-400' : 'bg-blue-500'
-              }`}
-              testID="preset-editor-save"
-              accessibilityState={{
-                busy: isLoading,
-                disabled: isSaveDisabled,
-              }}
-              accessibilityHint={
-                saveDisabledReason ? t(saveDisabledReason) : undefined
-              }
-            >
-              <Text className="text-white font-medium text-center">
-                {isLoading ? t('common.saving') : t('common.save')}
-              </Text>
-            </Pressable>
-          </HStack>
+              <Pressable
+                onPress={handleSave}
+                disabled={isSaveDisabled}
+                className={`flex-1 rounded-lg py-3 ${
+                  isSaveDisabled ? 'bg-gray-400' : 'bg-blue-500'
+                }`}
+                testID="preset-editor-save"
+                accessibilityState={{
+                  busy: isLoading,
+                  disabled: isSaveDisabled,
+                }}
+                accessibilityHint={
+                  saveDisabledReason ? t(saveDisabledReason) : undefined
+                }
+              >
+                <Text className="text-white font-medium text-center">
+                  {isLoading ? t('common.saving') : t('common.save')}
+                </Text>
+              </Pressable>
+            </HStack>
+          )}
         </Box>
         <KeyboardDoneAccessory
           accessibilityLabel={t('common.done')}

--- a/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
+++ b/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react-native'
-import { Alert, Keyboard } from 'react-native'
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
+import { Alert, Keyboard, TextInput } from 'react-native'
 import { Category, Task } from '@/src/types'
 import { PresetTaskEditor } from '../PresetTaskEditor'
 
@@ -44,6 +44,28 @@ const renderEditor = (overrides = {}) => {
     />
   )
 }
+
+interface RenderedInputWithTestId {
+  props: {
+    testID?: unknown
+  }
+}
+
+/**
+ * Reads task-title input IDs in screen order so category changes cannot reorder the active draft.
+ * @param inputs - The rendered React Native TextInput instances from the editor.
+ * @returns The task title test IDs in their current visual order.
+ * @example
+ * getTaskTitleInputTestIds(inputs) // => ['task-title-input-0', 'task-title-input-1']
+ */
+const getTaskTitleInputTestIds = (
+  inputs: RenderedInputWithTestId[]
+): string[] =>
+  inputs
+    .map((input) => input.props.testID)
+    .filter((testId): testId is string =>
+      String(testId).startsWith('task-title-input-')
+    )
 
 describe('PresetTaskEditor form safety', () => {
   beforeEach(() => {
@@ -98,6 +120,73 @@ describe('PresetTaskEditor form safety', () => {
     // Assert
     expect(getByTestId('task-title-input-2').props.autoFocus).toBe(true)
     expect(getByTestId('task-title-input-0').props.autoFocus).toBe(false)
+  })
+
+  it('hides the preset Save action while users type a newly added task', () => {
+    // Arrange
+    const { getByTestId, queryByTestId } = renderEditor()
+
+    // Act
+    fireEvent.press(getByTestId('add-task-button'))
+    fireEvent(getByTestId('task-title-input-2'), 'focus')
+
+    // Assert
+    expect(queryByTestId('preset-editor-save')).toBeNull()
+    expect(queryByTestId('preset-editor-cancel')).toBeNull()
+    expect(getByTestId('preset-editor-inline-keyboard-done-button')).toBeTruthy()
+  })
+
+  it('restores preset Save and Cancel actions after the native keyboard hides', () => {
+    // Arrange
+    const { getByTestId, queryByTestId } = renderEditor()
+    const keyboardDidHideHandler = (
+      Keyboard.addListener as jest.Mock
+    ).mock.calls.find(([eventName]) => eventName === 'keyboardDidHide')?.[1]
+
+    // Act
+    fireEvent.press(getByTestId('add-task-button'))
+    fireEvent(getByTestId('task-title-input-2'), 'focus')
+    act(() => {
+      keyboardDidHideHandler()
+    })
+
+    // Assert
+    expect(queryByTestId('preset-editor-inline-keyboard-done-button')).toBeNull()
+    expect(getByTestId('preset-editor-save')).toBeTruthy()
+    expect(getByTestId('preset-editor-cancel')).toBeTruthy()
+  })
+
+  it('keeps a newly added task in place when category changes during editing', () => {
+    // Arrange
+    const { UNSAFE_getAllByType, getByTestId } = renderEditor()
+
+    // Act
+    fireEvent.press(getByTestId('add-task-button'))
+    const inputOrderBeforeCategoryChange = getTaskTitleInputTestIds(
+      UNSAFE_getAllByType(TextInput)
+    )
+    fireEvent.changeText(getByTestId('task-title-input-2'), 'Read product notes')
+    fireEvent.press(getByTestId('latest-new-task-category-option-life'))
+    const inputOrderAfterCategoryChange = getTaskTitleInputTestIds(
+      UNSAFE_getAllByType(TextInput)
+    )
+
+    // Assert
+    expect(inputOrderBeforeCategoryChange).toEqual([
+      'task-title-input-0',
+      'task-title-input-1',
+      'task-title-input-2',
+    ])
+    expect(inputOrderAfterCategoryChange).toEqual(inputOrderBeforeCategoryChange)
+    expect(getByTestId('task-title-input-2').props.value).toBe(
+      'Read product notes'
+    )
+    expect(
+      getByTestId('latest-new-task-category-option-life').props
+        .accessibilityState
+    ).toEqual({
+      selected: true,
+    })
   })
 
   it('keeps preset text inputs above the keyboard and gives them a Done action', () => {


### PR DESCRIPTION
## Summary
- hide PresetTaskEditor footer Save/Cancel actions while a preset text input is actively using the keyboard Done action
- keep newly added preset tasks in stable row order when changing category, so the active draft does not jump offscreen
- add unit and Maestro regression coverage for the add-task keyboard/category flow

## Verification
- pnpm test src/components/__tests__/PresetTaskEditor.formSafety.test.tsx --runInBand
- pnpm typecheck
- pnpm lint
- pnpm test --runInBand
- pnpm exec expo install --check
- pnpm audit --audit-level=moderate
- pnpm deploy:check
- git diff --check
- pnpm build:e2e
- pnpm test:e2e:production:single maestro/ios/07-edit-presets.yaml
- pnpm test:e2e:production

## E2E Notes
- Final focused 07-edit-presets artifact: /Users/ryotamurakami/.maestro/tests/2026-06-15_224124
- Final full production suite artifact: /Users/ryotamurakami/.maestro/tests/2026-06-15_224157