### PR TITLE
fix: remove preset keyboard done controls

### DIFF
--- a/src/components/PresetTaskEditor.tsx
+++ b/src/components/PresetTaskEditor.tsx
@@ -167,6 +167,9 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
   const taskTitleInputRefs = useRef<Record<number, TextInput | null>>({})
   const taskMinutesInputRefs = useRef<Record<number, TextInput | null>>({})
   const newCategoryInputRef = useRef<TextInput>(null)
+  const pendingFooterRestoreFrameRef = useRef<
+    ReturnType<typeof requestAnimationFrame> | null
+  >(null)
   const taskValidation = useMemo(
     () => validatePresetTaskDrafts(editingTasks),
     [editingTasks]
@@ -205,12 +208,20 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
       'keyboardDidHide',
       () => {
         // Native keyboard dismissal should restore the footer actions too.
+        if (pendingFooterRestoreFrameRef.current !== null) {
+          cancelAnimationFrame(pendingFooterRestoreFrameRef.current)
+          pendingFooterRestoreFrameRef.current = null
+        }
         setIsPresetKeyboardVisible(false)
       }
     )
 
     return () => {
       keyboardDidHideSubscription.remove()
+      // Cancel deferred UI work when the editor unmounts.
+      if (pendingFooterRestoreFrameRef.current !== null) {
+        cancelAnimationFrame(pendingFooterRestoreFrameRef.current)
+      }
     }
   }, [])
 
@@ -281,17 +292,26 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
    * handlePresetInputFocus() // hides the preset editor footer actions
    */
   const handlePresetInputFocus = (): void => {
+    // A new field claimed focus before the footer could return, so keep it hidden.
+    if (pendingFooterRestoreFrameRef.current !== null) {
+      cancelAnimationFrame(pendingFooterRestoreFrameRef.current)
+      pendingFooterRestoreFrameRef.current = null
+    }
     setIsPresetKeyboardVisible(true)
   }
 
   /**
-   * Restores the preset footer after native text inputs lose focus.
-   * @returns Nothing; marks preset editing as no longer keyboard-active.
+   * Restores the preset footer after focus leaves every preset input for a full frame.
+   * @returns Nothing; defers restoration so field-to-field focus handoffs remain keyboard-active.
    * @example
-   * handlePresetInputBlur() // restores Save and Cancel after editing ends
+   * handlePresetInputBlur() // restores Save and Cancel unless another input receives focus
    */
   const handlePresetInputBlur = (): void => {
-    setIsPresetKeyboardVisible(false)
+    // Wait one frame so a title-to-minutes handoff can cancel this restoration.
+    pendingFooterRestoreFrameRef.current = requestAnimationFrame(() => {
+      pendingFooterRestoreFrameRef.current = null
+      setIsPresetKeyboardVisible(false)
+    })
   }
 
   /**

--- a/src/components/PresetTaskEditor.tsx
+++ b/src/components/PresetTaskEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef, useId } from 'react'
+import React, { useState, useEffect, useMemo, useRef } from 'react'
 import {
   Modal,
   SafeAreaView,
@@ -21,17 +21,12 @@ import {
   OperationFeedback,
   OperationFeedbackKind,
 } from '@/src/components/OperationFeedback'
-import { KeyboardDoneAccessory } from '@/src/components/KeyboardDoneAccessory'
 import { Task, Category } from '@/src/types'
 import { getCategoryDisplayName } from '@/src/i18n/config'
 import {
   PRESET_EDITOR_KEYBOARD_EXTRA_SCROLL_PADDING_PX,
   PRESET_TASK_FOCUS_SCROLL_OFFSET_PX,
 } from '@/src/constants/interaction'
-
-const PRESET_EDITOR_INPUT_ACCESSORY_VIEW_ID_PREFIX =
-  'preset-editor-input-accessory'
-const NATIVE_ID_UNSUPPORTED_CHARACTERS = /[^A-Za-z0-9_-]/g
 
 interface PresetTaskEditorProps {
   isVisible: boolean
@@ -165,19 +160,13 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
   const [pendingFocusedTaskIndex, setPendingFocusedTaskIndex] = useState<
     number | null
   >(null)
-  const [isPresetKeyboardDoneVisible, setIsPresetKeyboardDoneVisible] =
-    useState(false)
+  const [isPresetKeyboardVisible, setIsPresetKeyboardVisible] = useState(false)
   const [operationFeedback, setOperationFeedback] =
     useState<PresetEditorFeedback | null>(null)
   const taskListScrollViewRef = useRef<ScrollView>(null)
   const taskTitleInputRefs = useRef<Record<number, TextInput | null>>({})
   const taskMinutesInputRefs = useRef<Record<number, TextInput | null>>({})
   const newCategoryInputRef = useRef<TextInput>(null)
-  const reactId = useId()
-  const inputAccessoryViewID = `${PRESET_EDITOR_INPUT_ACCESSORY_VIEW_ID_PREFIX}-${reactId.replace(
-    NATIVE_ID_UNSUPPORTED_CHARACTERS,
-    ''
-  )}`
   const taskValidation = useMemo(
     () => validatePresetTaskDrafts(editingTasks),
     [editingTasks]
@@ -188,14 +177,14 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
   )
   const saveDisabledReason = taskValidation.formMessages[0] ?? null
   const isSaveDisabled = isLoading || !taskValidation.isValid
-  const shouldShowPresetEditorActions = !isPresetKeyboardDoneVisible
+  const shouldShowPresetEditorActions = !isPresetKeyboardVisible
 
   // Initialize editing tasks when modal opens
   useEffect(() => {
     if (isVisible) {
       setOperationFeedback(null)
       setPendingFocusedTaskIndex(null)
-      setIsPresetKeyboardDoneVisible(false)
+      setIsPresetKeyboardVisible(false)
       taskTitleInputRefs.current = {}
       taskMinutesInputRefs.current = {}
       setEditingTasks(
@@ -216,7 +205,7 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
       'keyboardDidHide',
       () => {
         // Native keyboard dismissal should restore the footer actions too.
-        setIsPresetKeyboardDoneVisible(false)
+        setIsPresetKeyboardVisible(false)
       }
     )
 
@@ -268,7 +257,7 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
   }
 
   /**
-   * Finishes preset text editing from the keyboard accessory or return key.
+   * Finishes preset text editing when a field's keyboard return key is pressed.
    * @returns Nothing; blurs known inputs and asks iOS to dismiss the keyboard.
    * @example
    * handleKeyboardDone() // closes the active preset editor keyboard
@@ -282,27 +271,27 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
     })
     newCategoryInputRef.current?.blur?.()
     Keyboard.dismiss()
-    setIsPresetKeyboardDoneVisible(false)
+    setIsPresetKeyboardVisible(false)
   }
 
   /**
-   * Shows the in-app Done control when a preset input receives focus in simulator hardware-keyboard mode.
-   * @returns Nothing; keeps the dismissal action visible until editing is explicitly finished.
+   * Tracks keyboard visibility so preset Save and Cancel stay hidden while a field is active.
+   * @returns Nothing; marks preset editing as keyboard-active.
    * @example
-   * handlePresetInputFocus() // reveals the preset editor Done button
+   * handlePresetInputFocus() // hides the preset editor footer actions
    */
   const handlePresetInputFocus = (): void => {
-    setIsPresetKeyboardDoneVisible(true)
+    setIsPresetKeyboardVisible(true)
   }
 
   /**
    * Restores the preset footer after native text inputs lose focus.
-   * @returns Nothing; hides the temporary keyboard Done action.
+   * @returns Nothing; marks preset editing as no longer keyboard-active.
    * @example
    * handlePresetInputBlur() // restores Save and Cancel after editing ends
    */
   const handlePresetInputBlur = (): void => {
-    setIsPresetKeyboardDoneVisible(false)
+    setIsPresetKeyboardVisible(false)
   }
 
   /**
@@ -562,7 +551,6 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
                           updateTask(task.index, { title: text })
                         }
                         autoFocus={task.index === pendingFocusedTaskIndex}
-                        inputAccessoryViewID={inputAccessoryViewID}
                         onFocus={handlePresetInputFocus}
                         onBlur={handlePresetInputBlur}
                         onSubmitEditing={handleKeyboardDone}
@@ -675,7 +663,6 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
                         placeholder={t(
                           'presetEditor.estimatedMinutesPlaceholder'
                         )}
-                        inputAccessoryViewID={inputAccessoryViewID}
                         keyboardType="numeric"
                         onFocus={handlePresetInputFocus}
                         onBlur={handlePresetInputBlur}
@@ -734,7 +721,6 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
                     value={newCategoryName}
                     onChangeText={setNewCategoryName}
                     placeholder={t('presetEditor.newCategoryPlaceholder')}
-                    inputAccessoryViewID={inputAccessoryViewID}
                     onFocus={handlePresetInputFocus}
                     onBlur={handlePresetInputBlur}
                     onSubmitEditing={handleKeyboardDone}
@@ -770,31 +756,16 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
         </ScrollView>
 
         {/* Footer */}
-        <Box className="p-4 border-t border-gray-200">
-          {isPresetKeyboardDoneVisible && (
-            <Box className="mb-3 items-end">
-              <Pressable
-                accessibilityLabel={t('common.done')}
-                accessibilityRole="button"
-                className="rounded-lg bg-blue-50 px-4 py-2"
-                onPress={handleKeyboardDone}
-                testID="preset-editor-inline-keyboard-done-button"
+        {shouldShowPresetEditorActions && (
+          <Box className="p-4 border-t border-gray-200">
+            {saveDisabledReason && (
+              <Text
+                className="mb-3 text-center text-sm font-medium text-red-600"
+                testID="preset-editor-save-disabled-reason"
               >
-                <Text className="text-base font-semibold text-blue-600">
-                  {t('common.done')}
-                </Text>
-              </Pressable>
-            </Box>
-          )}
-          {shouldShowPresetEditorActions && saveDisabledReason && (
-            <Text
-              className="mb-3 text-center text-sm font-medium text-red-600"
-              testID="preset-editor-save-disabled-reason"
-            >
-              {t(saveDisabledReason)}
-            </Text>
-          )}
-          {shouldShowPresetEditorActions && (
+                {t(saveDisabledReason)}
+              </Text>
+            )}
             <HStack space="md">
               <Pressable
                 onPress={handleCancel}
@@ -826,15 +797,8 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
                 </Text>
               </Pressable>
             </HStack>
-          )}
-        </Box>
-        <KeyboardDoneAccessory
-          accessibilityLabel={t('common.done')}
-          nativeID={inputAccessoryViewID}
-          onPress={handleKeyboardDone}
-          testID="preset-editor-keyboard-done-button"
-          title={t('common.done')}
-        />
+          </Box>
+        )}
         </KeyboardAvoidingView>
       </SafeAreaView>
     </Modal>

--- a/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
+++ b/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
@@ -5,6 +5,14 @@ import { Category, Task } from '@/src/types'
 import { PresetTaskEditor } from '../PresetTaskEditor'
 
 jest.spyOn(Alert, 'alert')
+globalThis.requestAnimationFrame = jest.fn()
+globalThis.cancelAnimationFrame = jest.fn()
+
+const pendingAnimationFrameCallbacks = new Map<
+  number,
+  Parameters<typeof requestAnimationFrame>[0]
+>()
+let nextAnimationFrameId = 0
 
 const mockCategories: Category[] = [
   { id: 'business', name: 'Business' },
@@ -70,6 +78,16 @@ const getTaskTitleInputTestIds = (
 describe('PresetTaskEditor form safety', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    pendingAnimationFrameCallbacks.clear()
+    nextAnimationFrameId = 0
+    jest.mocked(requestAnimationFrame).mockImplementation((callback) => {
+      nextAnimationFrameId += 1
+      pendingAnimationFrameCallbacks.set(nextAnimationFrameId, callback)
+      return nextAnimationFrameId
+    })
+    jest.mocked(cancelAnimationFrame).mockImplementation((frameId) => {
+      pendingAnimationFrameCallbacks.delete(frameId)
+    })
   })
 
   it('shows inline task-name validation while typing and explains disabled Save', () => {
@@ -229,6 +247,27 @@ describe('PresetTaskEditor form safety', () => {
     expect(queryByTestId('preset-editor-inline-keyboard-done-button')).toBeNull()
     expect(queryByTestId('preset-editor-keyboard-done-button')).toBeNull()
     expect(Keyboard.dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps preset actions hidden while focus moves from title to minutes', () => {
+    // Arrange
+    const { getByTestId, queryByTestId } = renderEditor()
+    const taskTitleInput = getByTestId('task-title-input-0')
+    const taskMinutesInput = getByTestId('task-minutes-input-0')
+
+    // Act
+    fireEvent(taskTitleInput, 'focus')
+    fireEvent(taskTitleInput, 'blur')
+    fireEvent(taskMinutesInput, 'focus')
+    act(() => {
+      // Run any uncancelled frame callbacks to prove the footer cannot return after handoff.
+      pendingAnimationFrameCallbacks.forEach((callback) => callback(0))
+    })
+
+    // Assert
+    expect(queryByTestId('preset-editor-save')).toBeNull()
+    expect(queryByTestId('preset-editor-cancel')).toBeNull()
+    expect(cancelAnimationFrame).toHaveBeenCalledTimes(1)
   })
 
   it('exposes selected state on category chips for screen readers', () => {

--- a/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
+++ b/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
@@ -133,7 +133,8 @@ describe('PresetTaskEditor form safety', () => {
     // Assert
     expect(queryByTestId('preset-editor-save')).toBeNull()
     expect(queryByTestId('preset-editor-cancel')).toBeNull()
-    expect(getByTestId('preset-editor-inline-keyboard-done-button')).toBeTruthy()
+    expect(queryByTestId('preset-editor-inline-keyboard-done-button')).toBeNull()
+    expect(queryByTestId('preset-editor-keyboard-done-button')).toBeNull()
   })
 
   it('restores preset Save and Cancel actions after the native keyboard hides', () => {
@@ -189,9 +190,9 @@ describe('PresetTaskEditor form safety', () => {
     })
   })
 
-  it('keeps preset text inputs above the keyboard and gives them a Done action', () => {
+  it('keeps preset text inputs above the keyboard without custom Done controls', () => {
     // Arrange
-    const { getAllByText, getByTestId, queryByTestId } = renderEditor()
+    const { getByTestId, queryByTestId } = renderEditor()
 
     // Act
     fireEvent.press(getByTestId('add-category-button'))
@@ -203,38 +204,31 @@ describe('PresetTaskEditor form safety', () => {
 
     expect(getByTestId('preset-editor-keyboard-avoiding-view')).toBeTruthy()
     expect(queryByTestId('preset-editor-inline-keyboard-done-button')).toBeNull()
-    expect(taskTitleInput.props.inputAccessoryViewID).toEqual(
-      expect.stringContaining('preset-editor-input-accessory')
-    )
-    expect(taskMinutesInput.props.inputAccessoryViewID).toBe(
-      taskTitleInput.props.inputAccessoryViewID
-    )
-    expect(newCategoryInput.props.inputAccessoryViewID).toBe(
-      taskTitleInput.props.inputAccessoryViewID
-    )
+    expect(queryByTestId('preset-editor-keyboard-done-button')).toBeNull()
+    expect(taskTitleInput.props.inputAccessoryViewID).toBeUndefined()
+    expect(taskMinutesInput.props.inputAccessoryViewID).toBeUndefined()
+    expect(newCategoryInput.props.inputAccessoryViewID).toBeUndefined()
     expect(taskTitleInput.props.returnKeyType).toBe('done')
     expect(taskTitleInput.props.submitBehavior).toBe('blurAndSubmit')
     expect(taskMinutesInput.props.returnKeyType).toBe('done')
     expect(newCategoryInput.props.returnKeyType).toBe('done')
     fireEvent(newCategoryInput, 'focus')
-    expect(getByTestId('preset-editor-inline-keyboard-done-button')).toBeTruthy()
-    expect(getAllByText('common.done').length).toBeGreaterThan(0)
+    expect(queryByTestId('preset-editor-inline-keyboard-done-button')).toBeNull()
+    expect(queryByTestId('preset-editor-keyboard-done-button')).toBeNull()
   })
 
-  it('dismisses the preset keyboard from the Done controls and return key', () => {
+  it('dismisses the preset keyboard from the return key without custom controls', () => {
     // Arrange
     const { getByTestId, queryByTestId } = renderEditor()
 
     // Act
-    fireEvent.press(getByTestId('preset-editor-keyboard-done-button'))
-    fireEvent(getByTestId('task-title-input-0'), 'focus')
-    fireEvent.press(getByTestId('preset-editor-inline-keyboard-done-button'))
     fireEvent(getByTestId('task-title-input-0'), 'focus')
     fireEvent(getByTestId('task-title-input-0'), 'submitEditing')
 
     // Assert
     expect(queryByTestId('preset-editor-inline-keyboard-done-button')).toBeNull()
-    expect(Keyboard.dismiss).toHaveBeenCalledTimes(3)
+    expect(queryByTestId('preset-editor-keyboard-done-button')).toBeNull()
+    expect(Keyboard.dismiss).toHaveBeenCalledTimes(1)
   })
 
   it('exposes selected state on category chips for screen readers', () => {


### PR DESCRIPTION
## Summary

- remove the inline Done button shown above the software keyboard in the preset task editor
- remove the preset-only iOS input accessory Done toolbar while retaining the keyboard return-key dismissal behavior
- keep Save and Cancel hidden while a preset field is focused and remove the now-empty footer area
- update form-safety regression coverage for the no-custom-Done behavior

## Validation

- pnpm test src/components/__tests__/PresetTaskEditor.formSafety.test.tsx --runInBand
- pnpm test:coverage --runInBand
- pnpm typecheck
- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard behavior in the preset task editor by simplifying keyboard dismissal and footer visibility.
  * The return key now dismisses the keyboard and completes editing more reliably.
  * Removed redundant inline “Done” controls while editing task details.
  * Save and Cancel actions now appear appropriately when the keyboard is hidden.

* **Tests**
  * Expanded preset keyboard form-safety coverage for return-key dismissal and focus transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->