### PR TITLE
fix: stabilize preset category button layout

### DIFF
--- a/src/components/PresetTaskEditor.tsx
+++ b/src/components/PresetTaskEditor.tsx
@@ -739,12 +739,13 @@ const PresetTaskEditorSession: React.FC<PresetTaskEditorProps> = ({
             {/* New Category Section */}
             <VStack space="sm" className="mb-4">
               <HStack className="items-center justify-between">
-                <Text className="text-lg font-semibold text-gray-800">
+                {/* Let the heading yield width while the action stays centered inside its minimum touch target. */}
+                <Text className="flex-1 mr-2 text-lg font-semibold text-gray-800">
                   {t('presetEditor.categoryManagement')}
                 </Text>
                 <Pressable
                   onPress={() => setShowNewCategoryInput(!showNewCategoryInput)}
-                  className="bg-green-500 rounded-lg px-3 py-2 touch-target-minimum"
+                  className="shrink-0 justify-center bg-green-500 rounded-lg px-3 py-2 touch-target-minimum"
                   testID="add-category-button"
                 >
                   <HStack className="items-center" space="xs">

--- a/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
+++ b/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
@@ -211,6 +211,34 @@ describe('PresetTaskEditor form safety', () => {
     })
   })
 
+  it('keeps the Add Category label inside its button when the section heading needs more width', () => {
+    // Arrange
+    const { getByTestId, getByText } = renderEditor()
+
+    // Act
+    const categoryManagementHeading = getByText(
+      'presetEditor.categoryManagement'
+    )
+    const addCategoryButton = getByTestId('add-category-button')
+
+    // Assert
+    expect(categoryManagementHeading.props.className).toContain('flex-1')
+    expect(categoryManagementHeading.props.className).toContain('mr-2')
+    expect(addCategoryButton.props.className).toContain('shrink-0')
+    expect(getByText('presetEditor.addCategory')).toBeTruthy()
+  })
+
+  it('centers the Add Category label vertically within its minimum touch target', () => {
+    // Arrange
+    const { getByTestId } = renderEditor()
+
+    // Act
+    const addCategoryButton = getByTestId('add-category-button')
+
+    // Assert
+    expect(addCategoryButton.props.className).toContain('justify-center')
+  })
+
   it('keeps preset text inputs above the keyboard without custom Done controls', () => {
     // Arrange
     const { getByTestId, queryByTestId } = renderEditor()


### PR DESCRIPTION
## Summary
- let the Category Management heading yield horizontal space while keeping Add Category fully visible
- vertically center the Add Category icon and label inside the minimum touch target
- add regression contracts for horizontal containment and vertical centering

## Validation
- CI=true pnpm test --runInBand --no-watchman (246 tests)
- pnpm lint
- pnpm typecheck
- pnpm quality:fallow
- git diff --check
- headless iOS visual comparison with Maestro; Simulator.app remained closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the New Category section layout so the heading and Add Category action are properly aligned.
  * Ensured the Add Category control maintains an appropriate touch target and centers its label for easier interaction.

* **Tests**
  * Added regression coverage for the updated category heading and Add Category button layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->