### PR TITLE
fix: prevent blank screen after saving presets

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Engage",
     "slug": "engage",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "engage",
@@ -14,7 +14,7 @@
     "description": "A minimal habit tracker focused on building consistent daily routines through task tracking, streak visualization, and reflective journaling.",
     "android": {
       "package": "com.laststance.engage",
-      "versionCode": 6,
+      "versionCode": 7,
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",
@@ -30,7 +30,7 @@
     },
     "ios": {
       "bundleIdentifier": "com.laststance.engage",
-      "buildNumber": "12",
+      "buildNumber": "13",
       "supportsTablet": false,
       "requireFullScreen": false,
       "infoPlist": {

--- a/maestro/README.md
+++ b/maestro/README.md
@@ -34,6 +34,7 @@ pnpm test:e2e:production:single maestro/ios/06-calendar-browsing.yaml
 - `07-edit-presets.yaml`: TaskPicker to PresetTaskEditor modal flow + keyboard/category stability regression
 - `10-data-persistence.yaml`: SQLite state survives restart
 - `11-backup-create.yaml`: backup creation regression
+- `12-calendar-preset-save.yaml`: nested Calendar preset save returns to DayModal without a white screen
 
 ### Tagged On-Demand Flows
 - `01-app-launch.yaml` (`smoke`): launch-only diagnosis

--- a/maestro/ios/12-calendar-preset-save.yaml
+++ b/maestro/ios/12-calendar-preset-save.yaml
@@ -47,7 +47,9 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "day-modal-close"
-    timeout: 10000
+    timeout: 15000
 
-- assertNotVisible:
-    id: "preset-editor-close"
+- extendedWaitUntil:
+    notVisible:
+      id: "preset-editor-close"
+    timeout: 15000

--- a/maestro/ios/12-calendar-preset-save.yaml
+++ b/maestro/ios/12-calendar-preset-save.yaml
@@ -1,0 +1,53 @@
+appId: com.laststance.engage
+tags:
+  - ios
+---
+# QA-12: Calendar Preset Save
+# Verifies saving presets dismisses only the editor and keeps DayModal visible.
+
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible:
+      id: "calendar-screen"
+    timeout: 10000
+
+# Open a calendar date so PresetTaskEditor is presented above DayModal.
+- tapOn:
+    id: "calendar-date-.*-01"
+    retryTapIfNoChange: false
+
+- extendedWaitUntil:
+    visible:
+      id: "day-modal-close"
+    timeout: 5000
+
+- tapOn:
+    id: ".*task-selection-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "edit-presets-button"
+    timeout: 5000
+
+- tapOn:
+    id: "edit-presets-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "preset-editor-save"
+    timeout: 5000
+
+# Regression: Save used to unmount the nested native Modal immediately,
+# leaving the iOS app window completely white.
+- tapOn:
+    id: "preset-editor-save"
+
+- extendedWaitUntil:
+    visible:
+      id: "day-modal-close"
+    timeout: 10000
+
+- assertNotVisible:
+    id: "preset-editor-close"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "engage",
   "main": "expo-router/entry",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "scripts": {
     "start": "expo start --port 8090",
     "android": "expo run:android --port 8090",

--- a/src/components/PresetTaskEditor.tsx
+++ b/src/components/PresetTaskEditor.tsx
@@ -210,7 +210,7 @@ export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
       onRequestClose={handleCancel}
     >
       <PresetTaskEditorSession
-        key={`${String(isVisible)}:${JSON.stringify(tasks)}`}
+        key={String(isVisible)}
         tasks={tasks}
         categories={categories}
         onSave={onSave}

--- a/src/components/PresetTaskEditor.tsx
+++ b/src/components/PresetTaskEditor.tsx
@@ -37,6 +37,8 @@ interface PresetTaskEditorProps {
   onCreateCategory: (name: string) => Promise<void>
 }
 
+type PresetTaskEditorSessionProps = Omit<PresetTaskEditorProps, 'isVisible'>
+
 interface EditingTask {
   id?: string
   title: string
@@ -71,6 +73,24 @@ interface PresetTaskValidation {
  * normalizeTaskTitle('  Reading  ') // => 'Reading'
  */
 const normalizeTaskTitle = (title: string): string => title.trim()
+
+/**
+ * Copies persisted tasks into editable drafts whenever a preset-editor session opens.
+ * @param tasks - The persisted preset tasks shown by the editor.
+ * @returns Independent drafts that form controls can update safely.
+ * @example
+ * createEditingTasks([{ id: 'task-1', title: 'Read', categoryId: 'life', archived: false, createdAt: 1, updatedAt: 1 }])
+ * // => [{ id: 'task-1', title: 'Read', categoryId: 'life', archived: false, isNew: false }]
+ */
+const createEditingTasks = (tasks: Task[]): EditingTask[] =>
+  tasks.map((task) => ({
+    id: task.id,
+    title: task.title,
+    categoryId: task.categoryId,
+    defaultMinutes: task.defaultMinutes,
+    archived: task.archived,
+    isNew: false,
+  }))
 
 /**
  * Builds inline validation state for the preset task editor as users type.
@@ -145,38 +165,13 @@ const validatePresetTaskDrafts = (
 }
 
 /**
- * Opens a fresh preset-editing session so closed modals cannot retain stale drafts.
+ * Keeps the native Modal mounted so iOS can dismiss it before keyed form content resets.
  * @param props - Visibility, source tasks, categories, and persistence callbacks.
- * @returns The active editor session, or `null` while the modal is closed.
+ * @returns A stable native Modal containing a fresh form for each visibility session.
  * @example
  * <PresetTaskEditor isVisible tasks={tasks} categories={categories} {...actions} />
  */
 export const PresetTaskEditor: React.FC<PresetTaskEditorProps> = ({
-  isVisible,
-  ...presetTaskEditorProps
-}) => {
-  // Closing the editor discards local form and keyboard state in one step.
-  if (!isVisible) {
-    return null
-  }
-
-  return (
-    <PresetTaskEditorSession
-      key={JSON.stringify(presetTaskEditorProps.tasks)}
-      isVisible={isVisible}
-      {...presetTaskEditorProps}
-    />
-  )
-}
-
-/**
- * Owns the editable task draft for one visible preset-editor session.
- * @param props - The open editor inputs and persistence callbacks.
- * @returns The visible preset task editor modal.
- * @example
- * <PresetTaskEditorSession isVisible tasks={tasks} categories={categories} {...actions} />
- */
-const PresetTaskEditorSession: React.FC<PresetTaskEditorProps> = ({
   isVisible,
   tasks,
   categories,
@@ -185,15 +180,64 @@ const PresetTaskEditorSession: React.FC<PresetTaskEditorProps> = ({
   onCreateCategory,
 }) => {
   const { t } = useTranslation()
+
+  /**
+   * Confirms discarded edits when the editor close button or native sheet dismissal triggers.
+   * @returns Nothing; invokes the parent cancellation only after confirmation.
+   * @example
+   * handleCancel() // => opens the discard confirmation
+   */
+  const handleCancel = (): void => {
+    Alert.alert(
+      t('presetEditor.discardChangesTitle'),
+      t('presetEditor.discardChangesMessage'),
+      [
+        { text: t('common.cancel'), style: 'cancel' },
+        {
+          text: t('presetEditor.discard'),
+          style: 'destructive',
+          onPress: onCancel,
+        },
+      ]
+    )
+  }
+
+  return (
+    <Modal
+      visible={isVisible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={handleCancel}
+    >
+      <PresetTaskEditorSession
+        key={`${String(isVisible)}:${JSON.stringify(tasks)}`}
+        tasks={tasks}
+        categories={categories}
+        onSave={onSave}
+        onCancel={handleCancel}
+        onCreateCategory={onCreateCategory}
+      />
+    </Modal>
+  )
+}
+
+/**
+ * Owns the editable form content mounted inside one native preset-editor session.
+ * @param props - The open editor inputs and persistence callbacks.
+ * @returns The preset editor form rendered inside the stable native Modal.
+ * @example
+ * <PresetTaskEditorSession tasks={tasks} categories={categories} {...actions} />
+ */
+const PresetTaskEditorSession: React.FC<PresetTaskEditorSessionProps> = ({
+  tasks,
+  categories,
+  onSave,
+  onCancel,
+  onCreateCategory,
+}) => {
+  const { t } = useTranslation()
   const [editingTasks, setEditingTasks] = useState<EditingTask[]>(() =>
-    tasks.map((task) => ({
-      id: task.id,
-      title: task.title,
-      categoryId: task.categoryId,
-      defaultMinutes: task.defaultMinutes,
-      archived: task.archived,
-      isNew: false,
-    }))
+    createEditingTasks(tasks)
   )
   const [isLoading, setSaving] = useState(false)
   const [newCategoryName, setNewCategoryName] = useState('')
@@ -482,29 +526,8 @@ const PresetTaskEditorSession: React.FC<PresetTaskEditorProps> = ({
     }
   }
 
-  const handleCancel = () => {
-    Alert.alert(
-      t('presetEditor.discardChangesTitle'),
-      t('presetEditor.discardChangesMessage'),
-      [
-        { text: t('common.cancel'), style: 'cancel' },
-        {
-          text: t('presetEditor.discard'),
-          style: 'destructive',
-          onPress: onCancel,
-        },
-      ]
-    )
-  }
-
   return (
-    <Modal
-      visible={isVisible}
-      animationType="slide"
-      presentationStyle="pageSheet"
-      onRequestClose={handleCancel}
-    >
-      <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-white">
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
           className="flex-1"
@@ -517,7 +540,7 @@ const PresetTaskEditorSession: React.FC<PresetTaskEditorProps> = ({
               {t('presetEditor.title')}
             </Text>
             <Pressable
-              onPress={handleCancel}
+              onPress={onCancel}
               className="p-2"
               testID="preset-editor-close"
             >
@@ -811,7 +834,7 @@ const PresetTaskEditorSession: React.FC<PresetTaskEditorProps> = ({
             )}
             <HStack space="md">
               <Pressable
-                onPress={handleCancel}
+                onPress={onCancel}
                 className="flex-1 bg-gray-100 rounded-lg py-3"
                 testID="preset-editor-cancel"
               >
@@ -844,6 +867,5 @@ const PresetTaskEditorSession: React.FC<PresetTaskEditorProps> = ({
         )}
         </KeyboardAvoidingView>
       </SafeAreaView>
-    </Modal>
   )
 }

--- a/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
+++ b/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native'
-import { Alert, Keyboard, TextInput } from 'react-native'
+import { Alert, Keyboard, Modal, TextInput } from 'react-native'
 import { Category, Task } from '@/src/types'
 import { PresetTaskEditor } from '../PresetTaskEditor'
 
@@ -176,6 +176,48 @@ describe('PresetTaskEditor form safety', () => {
     expect(queryByTestId('preset-editor-inline-keyboard-done-button')).toBeNull()
     expect(getByTestId('preset-editor-save')).toBeTruthy()
     expect(getByTestId('preset-editor-cancel')).toBeTruthy()
+  })
+
+  it('keeps the native Modal mounted while hidden so nested iOS sheets dismiss cleanly', () => {
+    // Arrange
+    const editorProps = {
+      categories: mockCategories,
+      onCancel: jest.fn(),
+      onCreateCategory: jest.fn(),
+      onSave: jest.fn(),
+      tasks: mockTasks,
+    }
+    const { UNSAFE_getByType, rerender } = render(
+      <PresetTaskEditor isVisible {...editorProps} />
+    )
+
+    // Act
+    rerender(<PresetTaskEditor isVisible={false} {...editorProps} />)
+
+    // Assert
+    expect(UNSAFE_getByType(Modal).props.visible).toBe(false)
+  })
+
+  it('reopens with persisted values instead of a discarded preset draft', () => {
+    // Arrange
+    const editorProps = {
+      categories: mockCategories,
+      onCancel: jest.fn(),
+      onCreateCategory: jest.fn(),
+      onSave: jest.fn(),
+      tasks: mockTasks,
+    }
+    const { getByTestId, rerender } = render(
+      <PresetTaskEditor isVisible {...editorProps} />
+    )
+    fireEvent.changeText(getByTestId('task-title-input-0'), 'Discarded draft')
+
+    // Act
+    rerender(<PresetTaskEditor isVisible={false} {...editorProps} />)
+    rerender(<PresetTaskEditor isVisible {...editorProps} />)
+
+    // Assert
+    expect(getByTestId('task-title-input-0').props.value).toBe('Networking')
   })
 
   it('keeps a newly added task in place when category changes during editing', () => {

--- a/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
+++ b/src/components/__tests__/PresetTaskEditor.formSafety.test.tsx
@@ -220,6 +220,32 @@ describe('PresetTaskEditor form safety', () => {
     expect(getByTestId('task-title-input-0').props.value).toBe('Networking')
   })
 
+  it('preserves the active draft when live preset tasks refresh while visible', () => {
+    // Arrange
+    const editorProps = {
+      categories: mockCategories,
+      isVisible: true,
+      onCancel: jest.fn(),
+      onCreateCategory: jest.fn(),
+      onSave: jest.fn(),
+    }
+    const { getByTestId, rerender } = render(
+      <PresetTaskEditor tasks={mockTasks} {...editorProps} />
+    )
+    fireEvent.changeText(getByTestId('task-title-input-0'), 'Active draft')
+
+    // Act
+    rerender(
+      <PresetTaskEditor
+        tasks={[{ ...mockTasks[0], title: 'Refreshed title' }, mockTasks[1]]}
+        {...editorProps}
+      />
+    )
+
+    // Assert
+    expect(getByTestId('task-title-input-0').props.value).toBe('Active draft')
+  })
+
   it('keeps a newly added task in place when category changes during editing', () => {
     // Arrange
     const { UNSAFE_getAllByType, getByTestId } = renderEditor()


### PR DESCRIPTION
## Summary
- keep the native preset editor Modal mounted while iOS dismisses its nested page sheet
- reset editable form state per visibility session without tearing down the native Modal
- add Jest and Maestro regression coverage for Calendar -> DayModal -> preset save
- prepare iOS release 1.0.8 (build 13)

## Root cause
Saving from the nested preset editor immediately unmounted the active React Native Modal. On iOS this could leave an empty native page sheet above the DayModal, producing a white screen.

## Validation
- pnpm exec jest --runInBand --watchman=false (249 passed)
- pnpm typecheck
- pnpm lint
- pnpm deploy:check
- git diff --check
- Release iOS simulator build succeeded
- maestro/ios/12-calendar-preset-save.yaml passed on iPhone 17 / iOS 26.5
- maestro/ios/07-edit-presets.yaml passed on rerun

## Known unrelated check
- pnpm exec expo install --check reports existing Expo 57 patch-version drift; dependency upgrades are intentionally excluded from this hotfix release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar preset saving to return reliably to the day view without displaying a blank screen.
  * Reopening the preset editor now restores saved task values and discards incomplete drafts correctly.
  * Preserving the editor while hidden improves draft handling during task updates.

* **Tests**
  * Added automated coverage for preset saving, modal dismissal, and draft restoration.

* **Chores**
  * Updated the app version to 1.0.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->