### PR TITLE
feat: add swipe-to-delete to task picker

### DIFF
--- a/app/(tabs)/today.tsx
+++ b/app/(tabs)/today.tsx
@@ -107,6 +107,7 @@ function TodayScreenContent() {
         categories={day.categories}
         selectedTasks={day.selectedTaskIds}
         onTaskSelect={day.handleTaskSelect}
+        onTaskDeleteAction={day.handleDeletePresetTask}
         onClose={day.handleTaskPickerClose}
         onEditPresets={handleEditPresets}
       />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import {
 } from 'expo-router/react-navigation'
 import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { useEffect } from 'react'
 import { LogBox } from 'react-native'
@@ -117,21 +118,24 @@ export default function RootLayout() {
   }, [initializeApp])
 
   return (
-    <SafeAreaProvider>
-      <GluestackUIProvider mode="light">
-        <ThemeProvider
-          value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
-        >
-          <Stack>
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen
-              name="modal"
-              options={{ presentation: 'modal', headerShown: false }}
-            />
-          </Stack>
-          <StatusBar style="auto" />
-        </ThemeProvider>
-      </GluestackUIProvider>
-    </SafeAreaProvider>
+    // Gesture Handler must own the app root so modal task rows receive native swipe events.
+    <GestureHandlerRootView className="flex-1">
+      <SafeAreaProvider>
+        <GluestackUIProvider mode="light">
+          <ThemeProvider
+            value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
+          >
+            <Stack>
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen
+                name="modal"
+                options={{ presentation: 'modal', headerShown: false }}
+              />
+            </Stack>
+            <StatusBar style="auto" />
+          </ThemeProvider>
+        </GluestackUIProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   )
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -42,6 +42,12 @@ export const unstable_settings = {
   anchor: '(tabs)',
 }
 
+/**
+ * Boots shared services and renders the provider tree whenever Expo Router mounts the app.
+ * @returns The application root with navigation, gestures, safe areas, and UI providers.
+ * @example
+ * <RootLayout />
+ */
 export default function RootLayout() {
   const colorScheme = useColorScheme()
   const initializeApp = useAppStore((state) => state.initializeApp)

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "typescript": "~6.0.3"
   },
   "private": true,
-  "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a",
+  "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
   "volta": {
     "node": "22.20.0"
   }

--- a/src/components/DayModal.tsx
+++ b/src/components/DayModal.tsx
@@ -86,6 +86,7 @@ export const DayModal: React.FC<DayModalProps> = ({ isVisible, onClose }) => {
           categories={day.categories}
           selectedTasks={day.selectedTaskIds}
           onTaskSelect={day.handleTaskSelect}
+          onTaskDeleteAction={day.handleDeletePresetTask}
           onClose={day.handleTaskPickerClose}
           onEditPresets={handleEditPresets}
         />

--- a/src/components/DayModal.tsx
+++ b/src/components/DayModal.tsx
@@ -18,6 +18,13 @@ interface DayModalProps {
   onClose: () => void
 }
 
+/**
+ * Presents a selected calendar day and its nested task flows when Calendar opens the day sheet.
+ * @param props - Modal visibility and the parent close callback.
+ * @returns The selected day's tasks, journal, picker, and preset editor.
+ * @example
+ * <DayModal isVisible onClose={handleClose} />
+ */
 export const DayModal: React.FC<DayModalProps> = ({ isVisible, onClose }) => {
   const { t } = useTranslation()
   const selectedDate = useAppStore((state) => state.selectedDate)

--- a/src/components/TaskPicker.tsx
+++ b/src/components/TaskPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useState } from 'react'
 import { Alert, Modal, ScrollView, StyleSheet } from 'react-native'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import Swipeable, {
   type SwipeableMethods,
 } from 'react-native-gesture-handler/ReanimatedSwipeable'
@@ -27,6 +28,21 @@ interface TaskPickerProps {
   onClose: () => void
   onEditPresets: () => void
 }
+
+/**
+ * Establishes the gesture boundary Android native modals cannot inherit from the app root.
+ * @param props - Picker content rendered inside the modal-safe gesture and safe-area roots.
+ * @returns A full-screen native-modal surface that can recognize row swipe gestures.
+ * @example
+ * <TaskPickerModalSurface>{pickerContent}</TaskPickerModalSurface>
+ */
+const TaskPickerModalSurface: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => (
+  <GestureHandlerRootView className="flex-1">
+    <SafeAreaView className="flex-1 bg-white">{children}</SafeAreaView>
+  </GestureHandlerRootView>
+)
 
 /**
  * Checks whether two task selections contain the same IDs regardless of tap order.
@@ -68,7 +84,6 @@ export const TaskPicker: React.FC<TaskPickerProps> = ({
 
   return (
     <TaskPickerSession
-      key={JSON.stringify(taskPickerProps.selectedTasks)}
       isVisible={isVisible}
       {...taskPickerProps}
     />
@@ -76,7 +91,7 @@ export const TaskPicker: React.FC<TaskPickerProps> = ({
 }
 
 /**
- * Owns one visible picker draft and remounts when the saved selection changes.
+ * Owns one visible picker draft and remounts only after the picker closes and reopens.
  * @param props - The open picker inputs and assignment callbacks.
  * @returns The visible modal session for selecting tasks.
  * @example
@@ -300,7 +315,7 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
       presentationStyle="pageSheet"
       onRequestClose={handleCancel}
     >
-      <SafeAreaView className="flex-1 bg-white">
+      <TaskPickerModalSurface>
         <VStack space="md" className="p-4 border-b border-gray-200">
           <HStack className="items-center justify-between">
             <VStack className="flex-1 mr-3" space="xs">
@@ -555,7 +570,7 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
             </AppPressable>
           </HStack>
         </Box>
-      </SafeAreaView>
+      </TaskPickerModalSurface>
     </Modal>
   )
 }

--- a/src/components/TaskPicker.tsx
+++ b/src/components/TaskPicker.tsx
@@ -1,5 +1,11 @@
 import React, { useMemo, useRef, useState } from 'react'
-import { Alert, Modal, ScrollView, StyleSheet } from 'react-native'
+import {
+  Alert,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  type AccessibilityActionEvent,
+} from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import Swipeable, {
   type SwipeableMethods,
@@ -133,8 +139,14 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
     [localSelectedTasks, selectedTasks]
   )
 
-  // Get category color using design system (lookup by category ID)
-  const getCategoryColor = (categoryId: string) => {
+  /**
+   * Maps a preset category to its design token whenever TaskPicker renders a section.
+   * @param categoryId - The persisted category ID for the visible task group.
+   * @returns A NativeWind background-color class with a safe business fallback.
+   * @example
+   * getCategoryColor('life') // => 'bg-life'
+   */
+  const getCategoryColor = (categoryId: string): string => {
     const colorMap: Record<string, string> = {
       business: 'bg-business',
       life: 'bg-life',
@@ -149,7 +161,14 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
     return colorMap[categoryId] || 'bg-business'
   }
 
-  const toggleTaskSelection = (taskId: string) => {
+  /**
+   * Updates the local draft when a user taps a task row before saving the day assignment.
+   * @param taskId - The preset task whose selected state should flip.
+   * @returns Nothing; local draft and visible error state are updated.
+   * @example
+   * toggleTaskSelection('task-1') // => task-1 toggles in the draft
+   */
+  const toggleTaskSelection = (taskId: string): void => {
     setErrorMessage(null)
     setLocalSelectedTasks((prev) => {
       if (prev.includes(taskId)) {
@@ -160,7 +179,13 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
     })
   }
 
-  const handleConfirm = async () => {
+  /**
+   * Persists the picker draft when the user presses Save and closes only after success.
+   * @returns A promise that settles after assignment feedback and modal state are synchronized.
+   * @example
+   * await handleConfirm() // => saves the selected task IDs
+   */
+  const handleConfirm = async (): Promise<void> => {
     // Do not overlap assignment persistence with a destructive task update.
     if (isSavingRef.current || deletingTaskIdRef.current !== null) {
       return
@@ -193,7 +218,13 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
     }
   }
 
-  const handleCancel = () => {
+  /**
+   * Discards the visible draft when the user closes the picker outside an active mutation.
+   * @returns Nothing; saved selections are restored before the modal closes.
+   * @example
+   * handleCancel() // => resets the draft and closes TaskPicker
+   */
+  const handleCancel = (): void => {
     // Keep the modal stable while a save or deletion is still persisting.
     if (isSavingRef.current || deletingTaskIdRef.current !== null) {
       return
@@ -204,7 +235,13 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
     onClose()
   }
 
-  const handleEditPresets = () => {
+  /**
+   * Opens PresetTaskEditor from TaskPicker when no save or deletion is still running.
+   * @returns Nothing; the parent swaps to the preset editing flow.
+   * @example
+   * handleEditPresets() // => opens the preset editor
+   */
+  const handleEditPresets = (): void => {
     // Avoid replacing this modal while a task mutation is still running.
     if (isSavingRef.current || deletingTaskIdRef.current !== null) {
       return
@@ -255,15 +292,15 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
    */
   const requestTaskDeletion = (
     task: Task,
-    swipeableMethods: SwipeableMethods
+    swipeableMethods?: SwipeableMethods
   ): void => {
     // Ignore swipe actions while another picker mutation is active.
     if (isSavingRef.current || deletingTaskIdRef.current !== null) {
-      swipeableMethods.close()
+      swipeableMethods?.close()
       return
     }
 
-    swipeableMethods.close()
+    swipeableMethods?.close()
     Alert.alert(
       t('presetEditor.deleteTask'),
       t('presetEditor.deleteTaskConfirm', { title: task.title }),
@@ -278,6 +315,23 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
         },
       ]
     )
+  }
+
+  /**
+   * Routes assistive-technology delete actions through the same confirmed destructive flow.
+   * @param task - The focused preset task exposed to VoiceOver or TalkBack.
+   * @param event - The accessibility action selected by the user.
+   * @returns Nothing; only the localized delete action opens confirmation.
+   * @example
+   * handleTaskAccessibilityAction(task, deleteActionEvent) // => shows confirmation
+   */
+  const handleTaskAccessibilityAction = (
+    task: Task,
+    event: AccessibilityActionEvent
+  ): void => {
+    if (event.nativeEvent.actionName === 'delete') {
+      requestTaskDeletion(task)
+    }
   }
 
   /**
@@ -427,6 +481,17 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
                             accessibilityHint={t(
                               'taskPicker.toggleSelectionHint'
                             )}
+                            accessibilityActions={[
+                              {
+                                name: 'delete',
+                                label: t('taskPicker.deletePresetAction'),
+                              },
+                            ]}
+                            onAccessibilityAction={(
+                              event: AccessibilityActionEvent
+                            ) =>
+                              handleTaskAccessibilityAction(task, event)
+                            }
                             className={`
                               p-4 border-2 touch-target-minimum
                               ${

--- a/src/components/TaskPicker.tsx
+++ b/src/components/TaskPicker.tsx
@@ -1,5 +1,8 @@
 import React, { useMemo, useRef, useState } from 'react'
-import { Modal, ScrollView, StyleSheet } from 'react-native'
+import { Alert, Modal, ScrollView, StyleSheet } from 'react-native'
+import Swipeable, {
+  type SwipeableMethods,
+} from 'react-native-gesture-handler/ReanimatedSwipeable'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useTranslation } from 'react-i18next'
 import { DesignSystem } from '@/constants/design-system'
@@ -20,6 +23,7 @@ interface TaskPickerProps {
   categories: Category[]
   selectedTasks: string[]
   onTaskSelect: (taskIds: string[]) => Promise<TaskAssignmentOperationResult>
+  onTaskDeleteAction: (taskId: string) => Promise<void>
   onClose: () => void
   onEditPresets: () => void
 }
@@ -84,6 +88,7 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
   categories,
   selectedTasks,
   onTaskSelect,
+  onTaskDeleteAction,
   onClose,
   onEditPresets,
 }) => {
@@ -93,6 +98,8 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
     useState<string[]>(selectedTasks)
   const [isSaving, setIsSaving] = useState(false)
   const isSavingRef = useRef(false)
+  const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null)
+  const deletingTaskIdRef = useRef<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const tasksByCategory = useMemo(
     () => groupTasksByCategory(presetTasks, categories),
@@ -105,6 +112,7 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
     [tasksByCategory]
   )
   const selectedTaskCount = localSelectedTasks.length
+  const isBusy = isSaving || deletingTaskId !== null
   const hasSelectionChanges = useMemo(
     () => !haveSameTaskSelection(localSelectedTasks, selectedTasks),
     [localSelectedTasks, selectedTasks]
@@ -138,7 +146,8 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
   }
 
   const handleConfirm = async () => {
-    if (isSavingRef.current) {
+    // Do not overlap assignment persistence with a destructive task update.
+    if (isSavingRef.current || deletingTaskIdRef.current !== null) {
       return
     }
 
@@ -170,7 +179,8 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
   }
 
   const handleCancel = () => {
-    if (isSavingRef.current) {
+    // Keep the modal stable while a save or deletion is still persisting.
+    if (isSavingRef.current || deletingTaskIdRef.current !== null) {
       return
     }
 
@@ -180,12 +190,108 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
   }
 
   const handleEditPresets = () => {
-    if (isSavingRef.current) {
+    // Avoid replacing this modal while a task mutation is still running.
+    if (isSavingRef.current || deletingTaskIdRef.current !== null) {
       return
     }
 
     onEditPresets()
   }
+
+  /**
+   * Permanently deletes a swiped preset and removes its stale local selection after confirmation.
+   * @param taskId - The persisted task ID selected by the destructive swipe action.
+   * @returns A promise that settles after persistence and picker state are synchronized.
+   * @example
+   * await deletePresetTask('task-1') // => task-1 disappears from the picker
+   */
+  const deletePresetTask = async (taskId: string): Promise<void> => {
+    // A second destructive tap must not start another database mutation.
+    if (isSavingRef.current || deletingTaskIdRef.current !== null) {
+      return
+    }
+
+    deletingTaskIdRef.current = taskId
+    setDeletingTaskId(taskId)
+    setErrorMessage(null)
+
+    try {
+      await onTaskDeleteAction(taskId)
+      setLocalSelectedTasks((currentTaskIds) =>
+        currentTaskIds.filter((currentTaskId) => currentTaskId !== taskId)
+      )
+    } catch (error) {
+      console.error('Failed to delete preset task:', error)
+      triggerFeedback('error')
+      setErrorMessage(t('taskPicker.deleteFailed'))
+    } finally {
+      deletingTaskIdRef.current = null
+      setDeletingTaskId(null)
+    }
+  }
+
+  /**
+   * Closes the swiped row and asks for confirmation before the destructive callback runs.
+   * @param task - The preset task exposed by the swipe gesture.
+   * @param swipeableMethods - Gesture Handler controls for closing the revealed action.
+   * @returns Nothing; confirmation triggers deletion only when the user accepts.
+   * @example
+   * requestTaskDeletion(task, swipeableMethods) // => shows the delete confirmation
+   */
+  const requestTaskDeletion = (
+    task: Task,
+    swipeableMethods: SwipeableMethods
+  ): void => {
+    // Ignore swipe actions while another picker mutation is active.
+    if (isSavingRef.current || deletingTaskIdRef.current !== null) {
+      swipeableMethods.close()
+      return
+    }
+
+    swipeableMethods.close()
+    Alert.alert(
+      t('presetEditor.deleteTask'),
+      t('presetEditor.deleteTaskConfirm', { title: task.title }),
+      [
+        { text: t('common.cancel'), style: 'cancel' },
+        {
+          text: t('common.delete'),
+          style: 'destructive',
+          onPress: () => {
+            void deletePresetTask(task.id)
+          },
+        },
+      ]
+    )
+  }
+
+  /**
+   * Renders the destructive control revealed when a picker row is swiped to the left.
+   * @param task - The preset task represented by the swiped row.
+   * @param swipeableMethods - Gesture Handler controls passed to the action renderer.
+   * @returns An accessible red delete action sized to the full task row.
+   * @example
+   * renderTaskDeleteAction(task, swipeableMethods) // => red Delete button
+   */
+  const renderTaskDeleteAction = (
+    task: Task,
+    swipeableMethods: SwipeableMethods
+  ): React.ReactNode => (
+    <AppPressable
+      onPress={() => requestTaskDeletion(task, swipeableMethods)}
+      disabled={isBusy}
+      feedback="select"
+      className="bg-system-red px-6 items-center justify-center touch-target-minimum"
+      pressedClassName="opacity-80"
+      testID={`task-picker-delete-${task.id}`}
+      accessibilityLabel={t('presetEditor.deleteTask')}
+      accessibilityRole="button"
+    >
+      <Text className="text-white font-semibold text-callout">
+        {t('common.delete')}
+      </Text>
+    </AppPressable>
+  )
 
   return (
     <Modal
@@ -220,7 +326,7 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
             </VStack>
             <AppPressable
               onPress={handleCancel}
-              disabled={isSaving}
+              disabled={isBusy}
               className="p-3 touch-target-minimum"
               pressedClassName="bg-system-gray-6 rounded-full"
               testID="task-picker-close"
@@ -237,7 +343,7 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
 
           <AppPressable
             onPress={handleEditPresets}
-            disabled={isSaving}
+            disabled={isBusy}
             feedback="select"
             className="bg-secondary-system-background rounded-lg p-3 touch-target-minimum"
             pressedClassName="bg-system-gray-5"
@@ -280,80 +386,95 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
                       )
 
                       return (
-                        <AppPressable
+                        <Swipeable
                           key={task.id}
-                          onPress={() => toggleTaskSelection(task.id)}
-                          feedback="select"
-                          selected={isSelected}
-                          accessibilityLabel={`${task.title}, ${selectionStatus}`}
-                          accessibilityValue={{
-                            text: selectionStatus,
-                          }}
-                          accessibilityHint={t(
-                            'taskPicker.toggleSelectionHint'
-                          )}
-                          className={`
-                            p-4 rounded-lg border-2 touch-target-minimum
-                            ${
-                              isSelected
-                                ? `border-system-blue bg-business-light`
-                                : 'border-system-gray-4 bg-system-background'
-                            }
-                          `}
-                          pressedClassName="bg-system-gray-6"
-                          testID={`task-picker-item-${task.id}`}
-                          accessibilityRole="button"
+                          enabled={!isBusy}
+                          overshootRight={false}
+                          renderRightActions={(
+                            _swipeProgress,
+                            _swipeTranslation,
+                            swipeableMethods
+                          ) =>
+                            renderTaskDeleteAction(task, swipeableMethods)
+                          }
+                          containerStyle={styles.swipeableContainer}
+                          testID={`task-picker-swipeable-${task.id}`}
                         >
-                          <HStack className="items-center justify-between">
-                            <VStack className="flex-1" space="xs">
-                              <Text
-                                className={`
-                                  text-body font-medium
-                                  ${
-                                    isSelected
-                                      ? 'text-system-blue'
-                                      : 'text-label'
-                                  }
-                                `}
-                              >
-                                {task.title}
-                              </Text>
-                              {task.defaultMinutes && (
-                                <Text className="text-footnote text-tertiary-label">
-                                  {t('taskPicker.estimatedTime', {
-                                    minutes: task.defaultMinutes,
-                                  })}
+                          <AppPressable
+                            onPress={() => toggleTaskSelection(task.id)}
+                            disabled={isBusy}
+                            feedback="select"
+                            selected={isSelected}
+                            accessibilityLabel={`${task.title}, ${selectionStatus}`}
+                            accessibilityValue={{
+                              text: selectionStatus,
+                            }}
+                            accessibilityHint={t(
+                              'taskPicker.toggleSelectionHint'
+                            )}
+                            className={`
+                              p-4 border-2 touch-target-minimum
+                              ${
+                                isSelected
+                                  ? `border-system-blue bg-business-light`
+                                  : 'border-system-gray-4 bg-system-background'
+                              }
+                            `}
+                            pressedClassName="bg-system-gray-6"
+                            testID={`task-picker-item-${task.id}`}
+                            accessibilityRole="button"
+                          >
+                            <HStack className="items-center justify-between">
+                              <VStack className="flex-1" space="xs">
+                                <Text
+                                  className={`
+                                    text-body font-medium
+                                    ${
+                                      isSelected
+                                        ? 'text-system-blue'
+                                        : 'text-label'
+                                    }
+                                  `}
+                                >
+                                  {task.title}
                                 </Text>
-                              )}
-                            </VStack>
-
-                            <HStack className="items-center" space="sm">
-                              {isSelected && (
-                                <Text className="text-caption-1 font-semibold text-system-blue">
-                                  {t('taskPicker.selectedStatus')}
-                                </Text>
-                              )}
-                              <Box
-                                className={`
-                                  w-6 h-6 rounded-full border-2 items-center justify-center
-                                  ${
-                                    isSelected
-                                      ? 'bg-system-blue border-system-blue'
-                                      : 'border-system-gray-3 bg-system-background'
-                                  }
-                                `}
-                              >
-                                {isSelected && (
-                                  <IconSymbol
-                                    name="checkmark"
-                                    size={16}
-                                    color="white"
-                                  />
+                                {task.defaultMinutes && (
+                                  <Text className="text-footnote text-tertiary-label">
+                                    {t('taskPicker.estimatedTime', {
+                                      minutes: task.defaultMinutes,
+                                    })}
+                                  </Text>
                                 )}
-                              </Box>
+                              </VStack>
+
+                              <HStack className="items-center" space="sm">
+                                {isSelected && (
+                                  <Text className="text-caption-1 font-semibold text-system-blue">
+                                    {t('taskPicker.selectedStatus')}
+                                  </Text>
+                                )}
+                                <Box
+                                  className={`
+                                    w-6 h-6 rounded-full border-2 items-center justify-center
+                                    ${
+                                      isSelected
+                                        ? 'bg-system-blue border-system-blue'
+                                        : 'border-system-gray-3 bg-system-background'
+                                    }
+                                  `}
+                                >
+                                  {isSelected && (
+                                    <IconSymbol
+                                      name="checkmark"
+                                      size={16}
+                                      color="white"
+                                    />
+                                  )}
+                                </Box>
+                              </HStack>
                             </HStack>
-                          </HStack>
-                        </AppPressable>
+                          </AppPressable>
+                        </Swipeable>
                       )
                     })}
                   </VStack>
@@ -368,7 +489,7 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
                 </Text>
                 <AppPressable
                   onPress={handleEditPresets}
-                  disabled={isSaving}
+                  disabled={isBusy}
                   feedback="select"
                   className="bg-system-blue rounded-lg px-6 py-3 touch-target-minimum"
                   pressedClassName="bg-business-dark"
@@ -395,7 +516,7 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
           <HStack space="md">
             <AppPressable
               onPress={handleCancel}
-              disabled={isSaving}
+              disabled={isBusy}
               className="flex-1 bg-secondary-system-background rounded-lg py-3 touch-target-minimum"
               pressedClassName="bg-system-gray-5"
               testID="task-picker-cancel"
@@ -411,6 +532,7 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
             <AppPressable
               onPress={handleConfirm}
               busy={isSaving}
+              disabled={isBusy}
               feedback="select"
               className="flex-1 bg-system-blue rounded-lg py-3 touch-target-minimum"
               pressedClassName="bg-business-dark"
@@ -441,5 +563,9 @@ const TaskPickerSession: React.FC<TaskPickerProps> = ({
 const styles = StyleSheet.create({
   primaryActionLabel: {
     color: DesignSystem.colors.system.systemBackground,
+  },
+  swipeableContainer: {
+    borderRadius: DesignSystem.borderRadius.button,
+    overflow: 'hidden',
   },
 })

--- a/src/components/__tests__/TaskPicker.test.tsx
+++ b/src/components/__tests__/TaskPicker.test.tsx
@@ -7,6 +7,7 @@ import { TaskPicker } from '../TaskPicker'
 
 interface SwipeableMockProps {
   children?: React.ReactNode
+  enabled?: boolean
   renderRightActions?: (
     progress: { value: number },
     translation: { value: number },
@@ -14,6 +15,15 @@ interface SwipeableMockProps {
   ) => React.ReactNode
   testID?: string
 }
+
+jest.mock('react-native-gesture-handler', () => {
+  const ReactModule = jest.requireActual<typeof import('react')>('react')
+
+  return {
+    GestureHandlerRootView: ({ children }: { children?: React.ReactNode }) =>
+      ReactModule.createElement('GestureHandlerRootView', {}, children),
+  }
+})
 
 jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
   const ReactModule = jest.requireActual<typeof import('react')>('react')
@@ -28,18 +38,17 @@ jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
     __esModule: true,
     default: ({
       children,
+      enabled = true,
       renderRightActions,
       testID,
     }: SwipeableMockProps) =>
       ReactModule.createElement(
         'ReanimatedSwipeable',
-        { testID },
+        { testID, enabled },
         children,
-        renderRightActions?.(
-          { value: 0 },
-          { value: 0 },
-          swipeableMethods
-        )
+        enabled
+          ? renderRightActions?.({ value: 0 }, { value: 0 }, swipeableMethods)
+          : null
       ),
   }
 })
@@ -215,8 +224,44 @@ describe('TaskPicker', () => {
     rerender(
       <TaskPicker
         {...defaultProps}
+        isVisible={false}
+        selectedTasks={['task1']}
+      />
+    )
+    rerender(
+      <TaskPicker
+        {...defaultProps}
         selectedTasks={['task2']}
         onTaskSelect={mockOnTaskSelect}
+      />
+    )
+    fireEvent.press(getByTestId('task-picker-confirm'))
+
+    // Assert
+    await waitFor(() => {
+      expect(mockOnTaskSelect).toHaveBeenCalledWith(['task2'])
+    })
+  })
+
+  it('preserves unsaved selections when an assigned preset is deleted', async () => {
+    // Arrange
+    const alertMock = jest.mocked(Alert.alert)
+    const { getByTestId, rerender } = render(
+      <TaskPicker {...defaultProps} selectedTasks={['task1']} />
+    )
+    fireEvent.press(getByTestId('task-picker-item-task2'))
+
+    // Act
+    fireEvent.press(getByTestId('task-picker-delete-task1'))
+    alertMock.mock.calls[0]?.[2]?.[1]?.onPress?.()
+    await waitFor(() => {
+      expect(mockOnTaskDeleteAction).toHaveBeenCalledWith('task1')
+    })
+    rerender(
+      <TaskPicker
+        {...defaultProps}
+        presetTasks={[mockTasks[1]]}
+        selectedTasks={[]}
       />
     )
     fireEvent.press(getByTestId('task-picker-confirm'))
@@ -267,6 +312,7 @@ describe('TaskPicker', () => {
     // Act
     fireEvent.press(getByTestId('task-picker-delete-task1'))
     expect(mockOnTaskDeleteAction).not.toHaveBeenCalled()
+    expect(alertMock).toHaveBeenCalledTimes(1)
     alertMock.mock.calls[0]?.[2]?.[1]?.onPress?.()
 
     // Assert
@@ -274,6 +320,34 @@ describe('TaskPicker', () => {
       expect(mockOnTaskDeleteAction).toHaveBeenCalledWith('task1')
     })
     expect(mockOnTaskDeleteAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks swipe deletion while task selection is saving', async () => {
+    // Arrange
+    let resolveSave: (result: TaskAssignmentOperationResult) => void = () => {}
+    mockOnTaskSelect.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSave = resolve
+      })
+    )
+    const { getByTestId, queryByTestId } = render(
+      <TaskPicker {...defaultProps} />
+    )
+
+    // Act
+    fireEvent.press(getByTestId('task-picker-confirm'))
+
+    // Assert
+    await waitFor(() => {
+      expect(queryByTestId('task-picker-delete-task1')).toBeNull()
+    })
+    expect(mockOnTaskDeleteAction).not.toHaveBeenCalled()
+
+    // Complete the pending save so React can finish the state transition.
+    resolveSave(successResult)
+    await waitFor(() => {
+      expect(mockOnClose).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('prevents duplicate assignment saves while confirm is already pending', async () => {

--- a/src/components/__tests__/TaskPicker.test.tsx
+++ b/src/components/__tests__/TaskPicker.test.tsx
@@ -347,6 +347,10 @@ describe('TaskPicker', () => {
     resolveSave(successResult)
     await waitFor(() => {
       expect(mockOnClose).toHaveBeenCalledTimes(1)
+      expect(
+        getByTestId('task-picker-swipeable-task1').props.enabled
+      ).toBe(true)
+      expect(getByTestId('task-picker-delete-task1')).toBeTruthy()
     })
   })
 

--- a/src/components/__tests__/TaskPicker.test.tsx
+++ b/src/components/__tests__/TaskPicker.test.tsx
@@ -1,7 +1,48 @@
 import React from 'react'
 import { render, fireEvent, waitFor } from '@testing-library/react-native'
+import { Alert } from 'react-native'
+import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable'
 import { Category, Task, TaskAssignmentOperationResult } from '@/src/types'
 import { TaskPicker } from '../TaskPicker'
+
+interface SwipeableMockProps {
+  children?: React.ReactNode
+  renderRightActions?: (
+    progress: { value: number },
+    translation: { value: number },
+    swipeableMethods: SwipeableMethods
+  ) => React.ReactNode
+  testID?: string
+}
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const ReactModule = jest.requireActual<typeof import('react')>('react')
+  const swipeableMethods: SwipeableMethods = {
+    close: jest.fn(),
+    openLeft: jest.fn(),
+    openRight: jest.fn(),
+    reset: jest.fn(),
+  }
+
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      renderRightActions,
+      testID,
+    }: SwipeableMockProps) =>
+      ReactModule.createElement(
+        'ReanimatedSwipeable',
+        { testID },
+        children,
+        renderRightActions?.(
+          { value: 0 },
+          { value: 0 },
+          swipeableMethods
+        )
+      ),
+  }
+})
 
 jest.mock('react-i18next', () => ({
   initReactI18next: {
@@ -16,7 +57,7 @@ jest.mock('react-i18next', () => ({
         'taskPicker.notSelectedStatus': 'Not selected',
         'taskPicker.selectedStatus': 'Selected',
         'taskPicker.toggleSelectionHint':
-          'Double tap to toggle whether this task is assigned for today.',
+          'Double tap to toggle this task for today. Swipe left to delete the preset.',
         'taskPicker.unsavedChanges': 'Unsaved changes',
       }
 
@@ -65,6 +106,7 @@ describe('TaskPicker', () => {
   }
 
   const mockOnTaskSelect = jest.fn<Promise<TaskAssignmentOperationResult>, [string[]]>()
+  const mockOnTaskDeleteAction = jest.fn<Promise<void>, [string]>()
   const mockOnClose = jest.fn()
   const mockOnEditPresets = jest.fn()
 
@@ -74,6 +116,7 @@ describe('TaskPicker', () => {
     presetTasks: mockTasks,
     selectedTasks: [],
     onTaskSelect: mockOnTaskSelect,
+    onTaskDeleteAction: mockOnTaskDeleteAction,
     onClose: mockOnClose,
     onEditPresets: mockOnEditPresets,
   }
@@ -81,6 +124,7 @@ describe('TaskPicker', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockOnTaskSelect.mockResolvedValue(successResult)
+    mockOnTaskDeleteAction.mockResolvedValue()
   })
 
   it('shows selectable preset tasks grouped by category', () => {
@@ -135,7 +179,9 @@ describe('TaskPicker', () => {
     })
     expect(
       getByTestId('task-picker-item-task1').props.accessibilityHint
-    ).toBe('Double tap to toggle whether this task is assigned for today.')
+    ).toBe(
+      'Double tap to toggle this task for today. Swipe left to delete the preset.'
+    )
     expect(
       getByTestId('task-picker-item-task1').props.accessibilityLabel
     ).toBe('ネットワーキング, Selected')
@@ -211,6 +257,23 @@ describe('TaskPicker', () => {
     // Assert
     expect(getByText('taskPicker.noPresetTasks')).toBeTruthy()
     expect(getByText('presetEditor.addTask')).toBeTruthy()
+  })
+
+  it('deletes the swiped preset only after the destructive action is confirmed', async () => {
+    // Arrange
+    const alertMock = jest.mocked(Alert.alert)
+    const { getByTestId } = render(<TaskPicker {...defaultProps} />)
+
+    // Act
+    fireEvent.press(getByTestId('task-picker-delete-task1'))
+    expect(mockOnTaskDeleteAction).not.toHaveBeenCalled()
+    alertMock.mock.calls[0]?.[2]?.[1]?.onPress?.()
+
+    // Assert
+    await waitFor(() => {
+      expect(mockOnTaskDeleteAction).toHaveBeenCalledWith('task1')
+    })
+    expect(mockOnTaskDeleteAction).toHaveBeenCalledTimes(1)
   })
 
   it('prevents duplicate assignment saves while confirm is already pending', async () => {

--- a/src/components/__tests__/TaskPicker.test.tsx
+++ b/src/components/__tests__/TaskPicker.test.tsx
@@ -64,9 +64,10 @@ jest.mock('react-i18next', () => ({
         'taskPicker.discardChanges': 'Discard changes',
         'taskPicker.discardChangesAndClose': 'Discard changes and close',
         'taskPicker.notSelectedStatus': 'Not selected',
+        'taskPicker.deletePresetAction': 'Delete preset',
         'taskPicker.selectedStatus': 'Selected',
         'taskPicker.toggleSelectionHint':
-          'Double tap to toggle this task for today. Swipe left to delete the preset.',
+          'Double tap to toggle this task for today. Swipe left or use the Delete preset action to delete it.',
         'taskPicker.unsavedChanges': 'Unsaved changes',
       }
 
@@ -189,8 +190,11 @@ describe('TaskPicker', () => {
     expect(
       getByTestId('task-picker-item-task1').props.accessibilityHint
     ).toBe(
-      'Double tap to toggle this task for today. Swipe left to delete the preset.'
+      'Double tap to toggle this task for today. Swipe left or use the Delete preset action to delete it.'
     )
+    expect(
+      getByTestId('task-picker-item-task1').props.accessibilityActions
+    ).toEqual([{ name: 'delete', label: 'Delete preset' }])
     expect(
       getByTestId('task-picker-item-task1').props.accessibilityLabel
     ).toBe('ネットワーキング, Selected')
@@ -320,6 +324,24 @@ describe('TaskPicker', () => {
       expect(mockOnTaskDeleteAction).toHaveBeenCalledWith('task1')
     })
     expect(mockOnTaskDeleteAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets assistive technology confirm and delete a preset', async () => {
+    // Arrange
+    const alertMock = jest.mocked(Alert.alert)
+    const { getByTestId } = render(<TaskPicker {...defaultProps} />)
+
+    // Act
+    fireEvent(getByTestId('task-picker-item-task1'), 'accessibilityAction', {
+      nativeEvent: { actionName: 'delete' },
+    })
+    expect(alertMock).toHaveBeenCalledTimes(1)
+    alertMock.mock.calls[0]?.[2]?.[1]?.onPress?.()
+
+    // Assert
+    await waitFor(() => {
+      expect(mockOnTaskDeleteAction).toHaveBeenCalledWith('task1')
+    })
   })
 
   it('blocks swipe deletion while task selection is saving', async () => {

--- a/src/hooks/useDayView.ts
+++ b/src/hooks/useDayView.ts
@@ -81,6 +81,21 @@ export function useDayView(date: string) {
     [updatePresetTasks],
   )
 
+  /**
+   * Deletes one preset from every day view when TaskPicker's swipe action is confirmed.
+   * @param taskId - The persisted preset task ID to remove.
+   * @returns A promise that settles after the shared preset list is persisted.
+   * @example
+   * await handleDeletePresetTask('task-1') // => task-1 is removed from TaskPicker
+   */
+  const handleDeletePresetTask = useCallback(
+    async (taskId: string): Promise<void> => {
+      // Submit the remaining source-of-truth list through the existing preset reconciler.
+      await updatePresetTasks(allTasks.filter((task) => task.id !== taskId))
+    },
+    [allTasks, updatePresetTasks],
+  )
+
   const handleCreateCategory = useCallback(
     async (name: string) => createCategory({ name }),
     [createCategory],
@@ -102,6 +117,7 @@ export function useDayView(date: string) {
     handleTaskPickerClose,
     handleTaskSelect,
     handleUpdatePresets,
+    handleDeletePresetTask,
     handleCreateCategory,
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -76,8 +76,9 @@ const en = {
     discardChanges: 'Discard changes',
     discardChangesAndClose: 'Discard changes and close',
     saveSelection: 'Save {{count}} selected tasks',
+    deletePresetAction: 'Delete preset',
     toggleSelectionHint:
-      'Double tap to toggle this task for today. Swipe left to delete the preset.',
+      'Double tap to toggle this task for today. Swipe left or use the Delete preset action to delete it.',
     newCategory: 'Create New Category',
     noPresetTasks: 'No preset tasks',
     confirm: 'Save selection ({{count}})',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -77,11 +77,12 @@ const en = {
     discardChangesAndClose: 'Discard changes and close',
     saveSelection: 'Save {{count}} selected tasks',
     toggleSelectionHint:
-      'Double tap to toggle whether this task is assigned for today.',
+      'Double tap to toggle this task for today. Swipe left to delete the preset.',
     newCategory: 'Create New Category',
     noPresetTasks: 'No preset tasks',
     confirm: 'Save selection ({{count}})',
     saveFailed: 'Failed to save task selection',
+    deleteFailed: 'Failed to delete the preset task',
   },
 
   presetEditor: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -76,11 +76,13 @@ const ja = {
     discardChanges: '変更を破棄',
     discardChangesAndClose: '変更を破棄して閉じる',
     saveSelection: '{{count}}個の選択を保存',
-    toggleSelectionHint: 'ダブルタップでこのタスクを今日の対象にするか切り替えます。',
+    toggleSelectionHint:
+      'ダブルタップで今日の対象を切り替えます。左にスワイプするとプリセットを削除できます。',
     newCategory: '新しいカテゴリーを作成',
     noPresetTasks: 'プリセットタスクがありません',
     confirm: '選択を保存 ({{count}}個)',
     saveFailed: 'タスク選択の保存に失敗しました',
+    deleteFailed: 'プリセットタスクの削除に失敗しました',
   },
 
   presetEditor: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -76,8 +76,9 @@ const ja = {
     discardChanges: '変更を破棄',
     discardChangesAndClose: '変更を破棄して閉じる',
     saveSelection: '{{count}}個の選択を保存',
+    deletePresetAction: 'プリセットを削除',
     toggleSelectionHint:
-      'ダブルタップで今日の対象を切り替えます。左にスワイプするとプリセットを削除できます。',
+      'ダブルタップで今日の対象を切り替えます。左にスワイプするか「プリセットを削除」アクションで削除できます。',
     newCategory: '新しいカテゴリーを作成',
     noPresetTasks: 'プリセットタスクがありません',
     confirm: '選択を保存 ({{count}}個)',

--- a/src/stores/__tests__/app-store.test.ts
+++ b/src/stores/__tests__/app-store.test.ts
@@ -6,6 +6,7 @@ import {
   categoryRepository,
 } from '../../services/repositories'
 import { journalService } from '../../services/journalService'
+import { databaseService } from '../../services/database'
 
 // Mock the repositories
 jest.mock('../../services/repositories', () => ({
@@ -41,6 +42,12 @@ jest.mock('../../services/repositories', () => ({
 jest.mock('../../services/journalService', () => ({
   journalService: {
     saveEntry: jest.fn(),
+  },
+}))
+
+jest.mock('../../services/database', () => ({
+  databaseService: {
+    executeTransaction: jest.fn(),
   },
 }))
 
@@ -108,6 +115,14 @@ describe('useAppStore', () => {
 
     // Reset mocks
     jest.clearAllMocks()
+    jest
+      .mocked(databaseService.executeTransaction)
+      .mockImplementation(async (operations) => {
+        // Match production ordering so store tests exercise every transactional operation.
+        for (const operation of operations) {
+          await operation()
+        }
+      })
   })
 
   describe('loadData', () => {
@@ -444,6 +459,7 @@ describe('useAppStore', () => {
 
       // Assert
       expect(taskRepository.delete).toHaveBeenCalledWith('task1')
+      expect(databaseService.executeTransaction).toHaveBeenCalledTimes(1)
       expect(useAppStore.getState().tasks).toEqual([mockTasks[1]])
       expect(useAppStore.getState().completions['2025-01-15']).toEqual([
         remainingCompletion,
@@ -466,6 +482,41 @@ describe('useAppStore', () => {
 
       // Assert
       expect(useAppStore.getState().completions).toBe(loadedCompletions)
+    })
+
+    it('keeps loaded task data unchanged when reconciliation fails after deletion', async () => {
+      // Arrange
+      const loadedCompletions = {
+        '2025-01-15': mockCompletions,
+      }
+      const editedTask = { ...mockTasks[1], title: '朝の運動' }
+      useAppStore.setState({
+        tasks: mockTasks,
+        completions: loadedCompletions,
+      })
+      jest
+        .mocked(taskRepository.update)
+        .mockRejectedValue(new Error('Update failed'))
+
+      // Act
+      const reconciliation = useAppStore
+        .getState()
+        .updatePresetTasks([editedTask])
+
+      // Assert
+      await expect(reconciliation).rejects.toThrow('Update failed')
+      expect(databaseService.executeTransaction).toHaveBeenCalledTimes(1)
+      expect(taskRepository.delete).toHaveBeenCalledWith('task1')
+      expect(taskRepository.update).toHaveBeenCalledWith('task2', {
+        title: '朝の運動',
+        categoryId: 'life',
+        archived: false,
+        updatedAt: mockTasks[1].updatedAt,
+      })
+      expect(taskRepository.findAll).not.toHaveBeenCalled()
+      expect(useAppStore.getState().tasks).toBe(mockTasks)
+      expect(useAppStore.getState().completions).toBe(loadedCompletions)
+      expect(useAppStore.getState().error).toBe('Update failed')
     })
   })
 

--- a/src/stores/__tests__/app-store.test.ts
+++ b/src/stores/__tests__/app-store.test.ts
@@ -12,6 +12,9 @@ jest.mock('../../services/repositories', () => ({
   taskRepository: {
     findAll: jest.fn(),
     seedDefaultTasks: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
   },
   entryRepository: {
     findRecentEntries: jest.fn(),
@@ -414,6 +417,36 @@ describe('useAppStore', () => {
       expect(state.completions['2025-01-15']).toEqual([
         concurrentlyUpdatedCompletion,
         assignedCompletion,
+      ])
+    })
+  })
+
+  describe('updatePresetTasks', () => {
+    it('removes a deleted preset from task lists and assigned days', async () => {
+      // Arrange
+      const remainingCompletion = {
+        id: 'comp2',
+        date: '2025-01-15',
+        taskId: 'task2',
+        completed: false,
+        createdAt: Date.now(),
+      }
+      useAppStore.setState({
+        tasks: mockTasks,
+        completions: {
+          '2025-01-15': [mockCompletions[0], remainingCompletion],
+        },
+      })
+      jest.mocked(taskRepository.findAll).mockResolvedValue([mockTasks[1]])
+
+      // Act
+      await useAppStore.getState().updatePresetTasks([mockTasks[1]])
+
+      // Assert
+      expect(taskRepository.delete).toHaveBeenCalledWith('task1')
+      expect(useAppStore.getState().tasks).toEqual([mockTasks[1]])
+      expect(useAppStore.getState().completions['2025-01-15']).toEqual([
+        remainingCompletion,
       ])
     })
   })

--- a/src/stores/__tests__/app-store.test.ts
+++ b/src/stores/__tests__/app-store.test.ts
@@ -449,6 +449,24 @@ describe('useAppStore', () => {
         remainingCompletion,
       ])
     })
+
+    it('preserves loaded day references when presets are edited without deletion', async () => {
+      // Arrange
+      const loadedCompletions = {
+        '2025-01-15': mockCompletions,
+      }
+      useAppStore.setState({
+        tasks: mockTasks,
+        completions: loadedCompletions,
+      })
+      jest.mocked(taskRepository.findAll).mockResolvedValue(mockTasks)
+
+      // Act
+      await useAppStore.getState().updatePresetTasks(mockTasks)
+
+      // Assert
+      expect(useAppStore.getState().completions).toBe(loadedCompletions)
+    })
   })
 
   describe('updateJournalEntry', () => {

--- a/src/stores/__tests__/app-store.test.ts
+++ b/src/stores/__tests__/app-store.test.ts
@@ -6,7 +6,7 @@ import {
   categoryRepository,
 } from '../../services/repositories'
 import { journalService } from '../../services/journalService'
-import { databaseService } from '../../services/database'
+import { databaseService } from '@/src/services/database'
 
 // Mock the repositories
 jest.mock('../../services/repositories', () => ({
@@ -45,7 +45,7 @@ jest.mock('../../services/journalService', () => ({
   },
 }))
 
-jest.mock('../../services/database', () => ({
+jest.mock('@/src/services/database', () => ({
   databaseService: {
     executeTransaction: jest.fn(),
   },

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -442,6 +442,13 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
+  /**
+   * Reconciles the complete preset list when PresetTaskEditor or TaskPicker submits a mutation.
+   * @param tasks - The complete preset list that should remain persisted.
+   * @returns A promise that settles after repository and loaded completion state agree.
+   * @example
+   * await useAppStore.getState().updatePresetTasks(remainingTasks)
+   */
   updatePresetTasks: async (tasks: Task[]) => {
     try {
       set({ error: null })
@@ -497,20 +504,25 @@ export const useAppStore = create<AppState>((set, get) => ({
       const updatedTasks = await taskRepository.findAll()
       const deletedTaskIds = new Set(tasksToDelete.map((task) => task.id))
 
-      set((current) => ({
-        tasks: updatedTasks,
-        // Mirror SQLite's cascading delete so loaded day assignments never retain ghost task IDs.
-        completions: Object.fromEntries(
-          Object.entries(current.completions).map(
-            ([date, dateCompletions]) => [
-              date,
-              dateCompletions.filter(
-                (completion) => !deletedTaskIds.has(completion.taskId)
-              ),
-            ]
-          )
-        ),
-      }))
+      // Preserve the completions reference when preset edits contain no deletions.
+      if (deletedTaskIds.size === 0) {
+        set({ tasks: updatedTasks })
+      } else {
+        set((current) => ({
+          tasks: updatedTasks,
+          // Mirror SQLite's cascading delete so loaded day assignments never retain ghost task IDs.
+          completions: Object.fromEntries(
+            Object.entries(current.completions).map(
+              ([date, dateCompletions]) => [
+                date,
+                dateCompletions.filter(
+                  (completion) => !deletedTaskIds.has(completion.taskId)
+                ),
+              ]
+            )
+          ),
+        }))
+      }
 
       console.log('Preset tasks updated successfully', {
         created: tasksToCreate.length,

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -495,7 +495,22 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       // Reload tasks from database to get accurate state
       const updatedTasks = await taskRepository.findAll()
-      set({ tasks: updatedTasks })
+      const deletedTaskIds = new Set(tasksToDelete.map((task) => task.id))
+
+      set((current) => ({
+        tasks: updatedTasks,
+        // Mirror SQLite's cascading delete so loaded day assignments never retain ghost task IDs.
+        completions: Object.fromEntries(
+          Object.entries(current.completions).map(
+            ([date, dateCompletions]) => [
+              date,
+              dateCompletions.filter(
+                (completion) => !deletedTaskIds.has(completion.taskId)
+              ),
+            ]
+          )
+        ),
+      }))
 
       console.log('Preset tasks updated successfully', {
         created: tasksToCreate.length,

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -48,6 +48,7 @@ import {
   calculateProductivityTrends,
 } from '../utils/statisticsEngine'
 import { backupService } from '../services/backupService'
+import { databaseService } from '../services/database'
 
 interface AppState {
   // Data
@@ -497,8 +498,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         })
       })
 
-      // Execute all operations
-      await Promise.all(operations.map((op) => op()))
+      // Keep deletes, creates, and updates atomic so a later failure restores earlier writes.
+      await databaseService.executeTransaction(operations)
 
       // Reload tasks from database to get accurate state
       const updatedTasks = await taskRepository.findAll()

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -48,7 +48,7 @@ import {
   calculateProductivityTrends,
 } from '../utils/statisticsEngine'
 import { backupService } from '../services/backupService'
-import { databaseService } from '../services/database'
+import { databaseService } from '@/src/services/database'
 
 interface AppState {
   // Data


### PR DESCRIPTION
## Summary
- add a native left-swipe delete action to tasks in the task picker
- confirm destructive deletion and keep task assignments synchronized with SQLite cascade deletes
- configure the Gesture Handler root and add regression coverage for the delete flow
- move the project from the broken pnpm 11.13.0 release to 11.13.1 so GitHub Actions can install dependencies

## Test plan
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:coverage --runInBand` (251 tests)
- `pnpm quality:fallow`
- `pnpm deploy:check`
- `pnpm exec expo export --platform ios`

## Baseline notes
- `pnpm exec expo install --check` reports pre-existing Expo-compatible patch drift
- `pnpm audit --audit-level=moderate` reports pre-existing transitive advisories; this PR does not change dependencies or the lockfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added swipe-left and accessibility-action deletion for preset tasks with confirmation prompts.
  * Added error feedback and improved accessibility guidance, including Japanese translations.
  * Prevented conflicting actions while saving or deleting tasks.

* **Bug Fixes**
  * Removed deleted preset tasks from associated completion records.
  * Cleared stale task assignments after preset deletion.
  * Preserved unsaved selections and removed deleted tasks from the current selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->