### PR TITLE
chore: release iOS 1.0.9

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Engage",
     "slug": "engage",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "engage",
@@ -30,7 +30,7 @@
     },
     "ios": {
       "bundleIdentifier": "com.laststance.engage",
-      "buildNumber": "13",
+      "buildNumber": "14",
       "supportsTablet": false,
       "requireFullScreen": false,
       "infoPlist": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "engage",
   "main": "expo-router/entry",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "scripts": {
     "start": "expo start --port 8090",
     "android": "expo run:android --port 8090",


### PR DESCRIPTION
## Summary

- bump the Expo and package versions to 1.0.9
- increment the iOS build number to 14
- keep the Android version code unchanged for this iOS-only release

## Validation

- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm lint
- pnpm test:coverage (256 tests)
- pnpm deploy:check
- pnpm exec expo install --check (reports the existing Expo SDK patch-version drift)
- pnpm audit --audit-level=moderate (reports the existing transitive dependency baseline; no dependency files changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to 1.0.9.
  * Incremented the iOS build number to 14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->